### PR TITLE
Move crawling of external APIs out of Flask application

### DIFF
--- a/flirror/__init__.py
+++ b/flirror/__init__.py
@@ -7,6 +7,7 @@ from .google_auth import (
     OAuth2View,
 )
 from .helpers import make_error_handler
+from .utils import weather_icon
 from .views import CalendarView, IndexView, MapView, WeatherView
 
 FLIRROR_SETTINGS_ENV = "FLIRROR_SETTINGS"
@@ -37,6 +38,9 @@ def create_app():
     app.register_error_handler(400, error_handler)
     app.register_error_handler(403, error_handler)
     app.register_error_handler(404, error_handler)
+
+    # Add custom Jinja2 template filters
+    app.add_template_filter(weather_icon)
 
     return app
 

--- a/flirror/crawler/__init__.py
+++ b/flirror/crawler/__init__.py
@@ -1,0 +1,4 @@
+import logging
+
+# Define root logger for the whole application
+LOGGER = logging.getLogger(__name__)

--- a/flirror/crawler/crawlers.py
+++ b/flirror/crawler/crawlers.py
@@ -12,29 +12,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 class WeatherCrawler:
-
-    # TODO Change to template filter registered by the weather module
-    weather_icons = {
-        "01d": "wi wi-day-sunny",
-        "02d": "wi wi-day-cloudy",
-        "03d": "wi wi-cloud",
-        "04d": "wi wi-cloudy",
-        "09d": "wi wi-day-showers",
-        "10d": "wi wi-day-rain",
-        "11d": "wi wi-day-thunderstorm",
-        "13d": "wi wi-day-snow",
-        "50d": "wi wi-dust",
-        "01n": "wi wi-night-clear",
-        "02n": "wi wi-night-alt-cloudy",
-        "03n": "wi wi-cloud",
-        "04n": "wi wi-cloudy",
-        "09n": "wi wi-night-showers-rain",
-        "10n": "wi wi-night-rain",
-        "11n": "wi wi-night-thunderstorm",
-        "13n": "wi wi-night-snow",
-        "50n": "wi wi-dust",
-    }
-
     def __init__(self, api_key, language, city, temp_unit):
         self.api_key = api_key
         self.language = language
@@ -94,7 +71,7 @@ class WeatherCrawler:
     def _parse_forecast_data(forecast, temp_unit):
         temperature = forecast.get_temperature(unit=temp_unit)
         return {
-            "date": forecast.get_reference_time(timeformat="date"),
+            "date": datetime.utcfromtimestamp(forecast.get_reference_time()),
             "temp_day": temperature["day"],
             "temp_night": temperature["night"],
             "status": forecast.get_status(),

--- a/flirror/crawler/crawlers.py
+++ b/flirror/crawler/crawlers.py
@@ -1,0 +1,78 @@
+import logging
+
+from pyowm import OWM
+from pyowm.exceptions.api_response_error import UnauthorizedError
+
+from flirror.exceptions import CrawlerDataError
+
+LOGGER = logging.getLogger(__name__)
+
+
+class WeatherCrawler:
+
+    # TODO Change to template filter registered by the weather module
+    weather_icons = {
+        "01d": "wi wi-day-sunny",
+        "02d": "wi wi-day-cloudy",
+        "03d": "wi wi-cloud",
+        "04d": "wi wi-cloudy",
+        "09d": "wi wi-day-showers",
+        "10d": "wi wi-day-rain",
+        "11d": "wi wi-day-thunderstorm",
+        "13d": "wi wi-day-snow",
+        "50d": "wi wi-dust",
+        "01n": "wi wi-night-clear",
+        "02n": "wi wi-night-alt-cloudy",
+        "03n": "wi wi-cloud",
+        "04n": "wi wi-cloudy",
+        "09n": "wi wi-night-showers-rain",
+        "10n": "wi wi-night-rain",
+        "11n": "wi wi-night-thunderstorm",
+        "13n": "wi wi-night-snow",
+        "50n": "wi wi-dust",
+    }
+
+    def __init__(self, api_key, language, city, temp_unit):
+        self.api_key = api_key
+        self.language = language
+        self.city = city
+        self.temp_unit = temp_unit
+        self._owm = None
+
+    def crawl(self):
+        try:
+            obs = self.owm.weather_at_place(self.city)
+        except UnauthorizedError as e:
+            raise CrawlerDataError from e
+
+        # Get today's weather and weekly forecast
+        weather = obs.get_weather()
+        fc = self.owm.daily_forecast(self.city, limit=7)
+
+        fc_data = []
+        # Skip the first element as we already have the weather for today
+        for fc_weather in list(fc.get_forecast())[1:]:
+            fc_data.append(self._parse_weather_data(fc_weather, self.temp_unit))
+        weather_data = self._parse_weather_data(weather, self.temp_unit)
+
+        result = {"city": self.city, "weather": weather_data, "forecast": fc_data}
+        print(result)
+
+    @property
+    def owm(self):
+        if self._owm is None:
+            self._owm = OWM(API_key=self.api_key, language=self.language, version="2.5")
+        return self._owm
+
+    def _parse_weather_data(self, weather, temp_unit):
+        return {
+            "date": weather.get_reference_time(timeformat="date"),
+            "temperature": weather.get_temperature(unit=temp_unit),
+            "status": weather.get_status(),
+            "detailed_status": weather.get_detailed_status(),
+            "sunrise_time": weather.get_sunrise_time("iso"),
+            "sunset_time": weather.get_sunset_time("iso"),
+            # TODO For the forecast we don't need the "detailed" icon
+            #  (no need to differentiate between day/night)
+            "icon_cls": self.weather_icons.get(weather.get_weather_icon_name()),
+        }

--- a/flirror/crawler/crawlers.py
+++ b/flirror/crawler/crawlers.py
@@ -154,8 +154,8 @@ class CalendarCrawler:
 
         # Sort the events from multiple calendars, but ignore the timezone
         # TODO Is that still needed when we have a database?
-        #all_events = sorted(all_events, key=lambda k: k["start"].replace(tzinfo=None))
-        #return all_events[: self.max_items]
+        # all_events = sorted(all_events, key=lambda k: k["start"].replace(tzinfo=None))
+        # return all_events[: self.max_items]
 
     @staticmethod
     @db_session
@@ -169,12 +169,18 @@ class CalendarCrawler:
         if end is None:
             end = event["end"].get("date")
 
+        # Convert strings to dates and set timezone info to none,
+        # as not all entries have time zone infos
+        # TODO: How to fix this?
+        start = dtparse(start).replace(tzinfo=None)
+        end = dtparse(end).replace(tzinfo=None)
+
         CalendarEvent(
             summary=event["summary"],
             # start.date -> whole day
             # start.dateTime -> specific time
-            start=dtparse(start),
-            end=dtparse(end),
+            start=start,
+            end=end,
             # The type reflects either whole day events or a specific time span
             type=type,
             location=event.get("location"),

--- a/flirror/crawler/crawlers.py
+++ b/flirror/crawler/crawlers.py
@@ -1,8 +1,11 @@
 import logging
+from datetime import datetime
 
+from pony.orm import db_session
 from pyowm import OWM
 from pyowm.exceptions.api_response_error import UnauthorizedError
 
+from flirror.database import Weather, WeatherForecast
 from flirror.exceptions import CrawlerDataError
 
 LOGGER = logging.getLogger(__name__)
@@ -39,6 +42,7 @@ class WeatherCrawler:
         self.temp_unit = temp_unit
         self._owm = None
 
+    @db_session
     def crawl(self):
         try:
             obs = self.owm.weather_at_place(self.city)
@@ -47,16 +51,20 @@ class WeatherCrawler:
 
         # Get today's weather and weekly forecast
         weather = obs.get_weather()
+
+        weather_data = self._parse_weather_data(weather, self.temp_unit, self.city)
+        # Store the weather information in sqlite
+        weather_obj = Weather(**weather_data)
+
+        # Get the forecast for the next days
         fc = self.owm.daily_forecast(self.city, limit=7)
 
-        fc_data = []
         # Skip the first element as we already have the weather for today
         for fc_weather in list(fc.get_forecast())[1:]:
-            fc_data.append(self._parse_weather_data(fc_weather, self.temp_unit))
-        weather_data = self._parse_weather_data(weather, self.temp_unit)
-
-        result = {"city": self.city, "weather": weather_data, "forecast": fc_data}
-        print(result)
+            fc_data = self._parse_forecast_data(fc_weather, self.temp_unit)
+            print(fc_data)
+            # Store the forecast information in sqlite
+            WeatherForecast(weather=weather_obj, **fc_data)
 
     @property
     def owm(self):
@@ -64,15 +72,34 @@ class WeatherCrawler:
             self._owm = OWM(API_key=self.api_key, language=self.language, version="2.5")
         return self._owm
 
-    def _parse_weather_data(self, weather, temp_unit):
+    @staticmethod
+    def _parse_weather_data(weather, temp_unit, city):
+        temp_dict = weather.get_temperature(unit=temp_unit)
         return {
-            "date": weather.get_reference_time(timeformat="date"),
-            "temperature": weather.get_temperature(unit=temp_unit),
+            "city": city,
+            "date": datetime.utcfromtimestamp(weather.get_reference_time()),
+            "temp_cur": temp_dict["temp"],
+            "temp_min": temp_dict["temp_min"],
+            "temp_max": temp_dict["temp_max"],
             "status": weather.get_status(),
             "detailed_status": weather.get_detailed_status(),
-            "sunrise_time": weather.get_sunrise_time("iso"),
-            "sunset_time": weather.get_sunset_time("iso"),
+            "sunrise_time": datetime.utcfromtimestamp(weather.get_sunrise_time()),
+            "sunset_time": datetime.utcfromtimestamp(weather.get_sunset_time()),
             # TODO For the forecast we don't need the "detailed" icon
             #  (no need to differentiate between day/night)
-            "icon_cls": self.weather_icons.get(weather.get_weather_icon_name()),
+            "icon": weather.get_weather_icon_name(),
+        }
+
+    @staticmethod
+    def _parse_forecast_data(forecast, temp_unit):
+        temperature = forecast.get_temperature(unit=temp_unit)
+        return {
+            "date": forecast.get_reference_time(timeformat="date"),
+            "temp_day": temperature["day"],
+            "temp_night": temperature["night"],
+            "status": forecast.get_status(),
+            "detailed_status": forecast.get_detailed_status(),
+            # TODO For the forecast we don't need the "detailed" icon
+            #  (no need to differentiate between day/night)
+            "icon": forecast.get_weather_icon_name(),
         }

--- a/flirror/crawler/main.py
+++ b/flirror/crawler/main.py
@@ -1,0 +1,65 @@
+import logging
+import os
+
+import click
+from flask.config import Config
+
+from flirror import FLIRROR_SETTINGS_ENV
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def configure_logger(verbosity):
+    # Import root logger to apply the configuration to all module loggers
+    from flirror.crawler import LOGGER
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.DEBUG)
+    log_formatter = logging.Formatter(
+        "%(asctime)s %(levelname)s [%(name)s] %(message)s", datefmt="%Y-%m-%dT%H:%M:%SZ"
+    )
+    console_handler.setFormatter(log_formatter)
+
+    level = getattr(logging, verbosity.upper())
+    environment_level = getattr(
+        logging, os.environ.get("FLIRROR_VERBOSITY", verbosity).upper()
+    )
+
+    LOGGER.setLevel(min(environment_level, level))
+    LOGGER.addHandler(console_handler)
+
+
+@click.group(invoke_without_command=True)
+@click.option(
+    "--verbosity",
+    help="Set the active log level",
+    default="info",
+    type=click.Choice(["debug", "info", "warning", "error"]),
+)
+@click.pass_context
+def main(ctx, verbosity):
+    configure_logger(verbosity)
+
+    # Load the configurations from file
+    config = Config(root_path=".")
+    # TODO Add default settings, once we have some
+    # config.from_object(default_settings)
+    config.from_envvar(FLIRROR_SETTINGS_ENV)
+
+    # TODO Validate config?
+    # Store everything in click's context object to be available for subcommands
+    ctx.obj = {
+        "config": config,
+    }
+
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(crawl)
+
+
+def crawl():
+    LOGGER.info("Hello, Flirror!")
+
+
+if __name__ == "__main__":
+    main()

--- a/flirror/crawler/main.py
+++ b/flirror/crawler/main.py
@@ -5,7 +5,7 @@ import click
 from flask.config import Config
 
 from flirror import FLIRROR_SETTINGS_ENV
-from flirror.crawler.crawlers import WeatherCrawler
+from flirror.crawler.crawlers import CalendarCrawler, WeatherCrawler
 
 
 LOGGER = logging.getLogger(__name__)
@@ -63,7 +63,10 @@ def crawl(ctx):
     config = ctx.obj["config"]
 
     # TODO Look up crawlers from config file
-    for name, crawler_cls in [("weather", WeatherCrawler)]:
+    for name, crawler_cls in [
+        ("weather", WeatherCrawler),
+        ("calendar", CalendarCrawler),
+    ]:
         settings = config["MODULES"].get(name)
         crawler = crawler_cls(**settings)
         crawler.crawl()

--- a/flirror/crawler/main.py
+++ b/flirror/crawler/main.py
@@ -5,6 +5,7 @@ import click
 from flask.config import Config
 
 from flirror import FLIRROR_SETTINGS_ENV
+from flirror.crawler.crawlers import WeatherCrawler
 
 
 LOGGER = logging.getLogger(__name__)
@@ -49,16 +50,23 @@ def main(ctx, verbosity):
 
     # TODO Validate config?
     # Store everything in click's context object to be available for subcommands
-    ctx.obj = {
-        "config": config,
-    }
+    ctx.obj = {"config": config}
 
     if ctx.invoked_subcommand is None:
         ctx.invoke(crawl)
 
 
-def crawl():
+@click.pass_context
+def crawl(ctx):
     LOGGER.info("Hello, Flirror!")
+
+    config = ctx.obj["config"]
+
+    # TODO Look up crawlers from config file
+    for name, crawler_cls in [("weather", WeatherCrawler)]:
+        settings = config["MODULES"].get(name)
+        crawler = crawler_cls(**settings)
+        crawler.crawl()
 
 
 if __name__ == "__main__":

--- a/flirror/database.py
+++ b/flirror/database.py
@@ -36,6 +36,14 @@ class Oauth2Credentials(db.Entity):
     token_uri = Required(str)
 
 
+class CalendarEvent(db.Entity):
+    summary = Required(str)
+    start = Required(ormtypes.datetime)
+    end = Required(ormtypes.datetime)
+    type = Required(str)
+    location = Optional(str)
+
+
 # Connect to the database and create it if it doesn't exist
 db.bind(provider="sqlite", filename="database.sqlite", create_db=True)
 

--- a/flirror/database.py
+++ b/flirror/database.py
@@ -1,0 +1,38 @@
+from pony.orm import Database, ormtypes, Required, set_sql_debug, Set
+
+db = Database()
+
+
+class WeatherBasic(db.Entity):
+    date = Required(ormtypes.datetime)
+    status = Required(str)
+    detailed_status = Required(str)
+    icon = Required(str)
+
+
+class Weather(WeatherBasic):
+    city = Required(str)
+    temp_cur = Required(float)
+    temp_min = Required(float)
+    temp_max = Required(float)
+    sunrise_time = Required(ormtypes.datetime)
+    sunset_time = Required(ormtypes.datetime)
+    # foreign-key relation to forecasts
+    forecasts = Set("WeatherForecast")
+
+
+class WeatherForecast(WeatherBasic):
+    temp_day = Required(float)
+    temp_night = Required(float)
+    # foreign-key relation to weather
+    weather = Required(Weather)
+
+
+# Connect to the database and create it if it doesn't exist
+db.bind(provider="sqlite", filename="database.sqlite", create_db=True)
+
+# Create the tables if they don't exist
+db.generate_mapping(create_tables=True)
+
+# Activate pony's debug mode
+set_sql_debug(True)

--- a/flirror/database.py
+++ b/flirror/database.py
@@ -1,4 +1,4 @@
-from pony.orm import Database, ormtypes, Required, set_sql_debug, Set
+from pony.orm import Database, Optional, ormtypes, Required, set_sql_debug, Set
 
 db = Database()
 
@@ -26,6 +26,14 @@ class WeatherForecast(WeatherBasic):
     temp_night = Required(float)
     # foreign-key relation to weather
     weather = Required(Weather)
+
+
+class Oauth2Credentials(db.Entity):
+    date = Required(ormtypes.datetime)
+    client_id = Required(str)
+    client_secret = Required(str)
+    token = Required(str)
+    token_uri = Required(str)
 
 
 # Connect to the database and create it if it doesn't exist

--- a/flirror/database.py
+++ b/flirror/database.py
@@ -41,7 +41,7 @@ class CalendarEvent(db.Entity):
     start = Required(ormtypes.datetime)
     end = Required(ormtypes.datetime)
     type = Required(str)
-    location = Optional(str)
+    location = Optional(str, nullable=True)
 
 
 # Connect to the database and create it if it doesn't exist

--- a/flirror/exceptions.py
+++ b/flirror/exceptions.py
@@ -1,0 +1,4 @@
+class CrawlerDataError(Exception):
+    """Exception if some data could not be retrieved by a crawler."""
+
+    pass

--- a/flirror/templates/weather.html
+++ b/flirror/templates/weather.html
@@ -8,17 +8,17 @@
 <div class="container">
     <div class="card weather-card bg-dark text-white text-center">
         <div class="card-body pb-3">
-        <h3 class="card-title font-weight-bold">{{ city }}</h3>
+        <h3 class="card-title font-weight-bold">{{ weather.city }}</h3>
             <p class="card-text"><span class="mr-3">{{ weather.date.strftime("%A") | upper }}</span>{{ weather.date.strftime("%b %d, %Y")}}</p>
             <div class="row mb-3">
                 <div class="col-2"></div>
                 <div class="col-4 align-self-center">
-                    <i class="{{ weather.icon_cls }} weather-icon mr-2"></i>
+                    <i class="{{ weather.icon | weather_icon }} weather-icon mr-2"></i>
                 </div>
                 <div class="col-4">
-                    <h3 class="mt-3 mb-3">{{ "%2.0f" % weather.temperature.temp }}° C</h3>
+                    <h3 class="mt-3 mb-3">{{ "%2.0f" % weather.temp_cur }}° C</h3>
                     <p>
-                        {{ "%2.0f" % weather.temperature.temp_min }}° C - {{ "%2.0f" % weather.temperature.temp_max }}° C
+                        {{ "%2.0f" % weather.temp_min }}° C - {{ "%2.0f" % weather.temp_max }}° C
                     </p>
                     <p>{{ weather.detailed_status }}</p>
                 </div>
@@ -26,12 +26,12 @@
             <div class="col-2"></div>
         </div>
         <div class="row">
-            {% for fc in forecast %}
+            {% for fc in forecasts %}
             <div class="col-2">
                 <p class="small">{{ fc.date.strftime("%a") | upper }}</p>
-                <p><i class="{{ fc.icon_cls }}"></i></p>
+                <p><i class="{{ fc.icon | weather_icon }}"></i></p>
                 <p class="small">
-                    {{ "%2.0f" % fc.temperature.day }}° C / {{ "%2.0f" % fc.temperature.night }}° C
+                    {{ "%2.0f" % fc.temp_day }}° C / {{ "%2.0f" % fc.temp_night }}° C
                 </p>
             </div>
             {% endfor %}

--- a/flirror/utils.py
+++ b/flirror/utils.py
@@ -1,0 +1,25 @@
+
+weather_icons = {
+    "01d": "wi wi-day-sunny",
+    "02d": "wi wi-day-cloudy",
+    "03d": "wi wi-cloud",
+    "04d": "wi wi-cloudy",
+    "09d": "wi wi-day-showers",
+    "10d": "wi wi-day-rain",
+    "11d": "wi wi-day-thunderstorm",
+    "13d": "wi wi-day-snow",
+    "50d": "wi wi-dust",
+    "01n": "wi wi-night-clear",
+    "02n": "wi wi-night-alt-cloudy",
+    "03n": "wi wi-cloud",
+    "04n": "wi wi-cloudy",
+    "09n": "wi wi-night-showers-rain",
+    "10n": "wi wi-night-rain",
+    "11n": "wi wi-night-thunderstorm",
+    "13n": "wi wi-night-snow",
+    "50n": "wi wi-dust",
+}
+
+
+def weather_icon(icon_name):
+    return weather_icons.get(icon_name)

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -1,15 +1,11 @@
 import abc
 from datetime import datetime
 
-import flask
-import google.oauth2.credentials
-import googleapiclient.discovery
-from dateutil.parser import parse as dtparse
-from flask import abort, current_app, render_template
+from flask import current_app, render_template
 from flask.views import MethodView
 from pony.orm import db_session, desc, select
 
-from flirror.database import Oauth2Credentials, Weather, WeatherForecast
+from flirror.database import Weather
 
 
 class FlirrorMethodView(MethodView):
@@ -92,16 +88,7 @@ class CalendarView(FlirrorMethodView):
     api_service_name = "calendar"
     api_version = "v3"
 
-    # TODO Maybe we could use this also as a fallback if no calendar from the list matched
-    default_calendars = ["primary"]
     default_max_items = 5
-
-    @db_session
-    def get_credentials(self):
-        for credentials in select(c for c in Oauth2Credentials).order_by(
-            desc(Oauth2Credentials.date)
-        ):
-            return credentials
 
     def get(self):
         # Get view-specific settings from config
@@ -110,20 +97,7 @@ class CalendarView(FlirrorMethodView):
         max_items = settings.get("max_items", self.default_max_items)
 
         cred = self.get_credentials()
-        # TODO Retrieve a new token, if none could be found
-        #   if "oauth2_credentials" not in flask.session:
-        #     return flask.redirect(flask.url_for("oauth2"))
 
-        credentials = google.oauth2.credentials.Credentials(
-            client_id=cred.client_id,
-            client_secret=cred.client_secret,
-            token=cred.token,
-            token_uri=cred.token_uri
-        )
-
-        service = googleapiclient.discovery.build(
-            self.api_service_name, self.api_version, credentials=credentials
-        )
 
         events, events_json = self.get_events(service, calendars, max_items)
         context = self.get_context(events=events, events_json=events_json)
@@ -134,18 +108,8 @@ class CalendarView(FlirrorMethodView):
         # Use the value from config
         calendar_list = api_service.calendarList().list().execute()
         calendar_items = calendar_list.get("items")
-        [
-            current_app.logger.info("%s: %s", i["id"], i["summary"])
-            for i in calendar_items
-        ]
-        cals_filtered = [
-            ci for ci in calendar_items if ci["summary"].lower() in calendars
-        ]
         current_app.logger.info("%s", cals_filtered)
-        if not cals_filtered:
-            # TODO Render error page with message
-            current_app.logger.error("Could not find calendar with names %s", calendars)
-            return
+
         for cal_item in cals_filtered:
             # Call the calendar API
             now = "{}Z".format(datetime.utcnow().isoformat())  # 'Z' indicates UTC time
@@ -168,26 +132,6 @@ class CalendarView(FlirrorMethodView):
         all_events = sorted(all_events, key=lambda k: k["start"].replace(tzinfo=None))
         return all_events[:max_items], events
 
-    @staticmethod
-    def _parse_event_data(event):
-        start = event["start"].get("dateTime")
-        type = "time"
-        if start is None:
-            start = event["start"].get("date")
-            type = "day"
-        end = event["end"].get("dateTime")
-        if end is None:
-            end = event["end"].get("date")
-        return {
-            "summary": event["summary"],
-            # start.date -> whole day
-            # start.dateTime -> specific time
-            "start": dtparse(start),
-            "end": dtparse(end),
-            # The type reflects either whole day events or a specific time span
-            "type": type,
-            "location": event.get("location"),
-        }
 
 
 class MapView(FlirrorMethodView):

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ requires = [
     "google-api-python-client",
     "google-auth-httplib2",
     "google-auth-oauthlib",
+    "pony",
     "pyowm",
     "python-dateutil",
 ]

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ with open("README.md") as readme:
     long_description = readme.read()
 
 requires = [
+    "click",
     "flask",
     "google-api-python-client",
     "google-auth-httplib2",
@@ -30,6 +31,8 @@ setup(
     packages=find_packages(),
     zip_safe=False,
     include_package_data=True,
-    # TODO entry_points (collect static?)
+    entry_points={
+        "console_scripts": ["flirror-crawler = flirror.crawler.main:main"],
+    },
     # TODO classifiers for PyPI
 )


### PR DESCRIPTION
This was nice for the start, but shouldn't be done this way. Thus,
all external APIs can now be scraped with the flirror-crawler command
line tool and store there results in a sqlite database. The flirror
webserver retrieves the data to show from this database.