### PR TITLE
Use single data objects per crawler to only store the current data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Application files
+settings.cfg
+.env
+database.sqlite
+
+# Python
+.eggs
+*.egg-info
+__pycache__
+build/
+dist/
+
+# Development and OS
+.idea
+.DS_Store

--- a/flirror/crawler/google_auth.py
+++ b/flirror/crawler/google_auth.py
@@ -7,7 +7,7 @@ import requests
 from google_auth_oauthlib.flow import Flow
 from pony.orm import db_session, ObjectNotFound
 
-from flirror.database import FlirrorObject
+from flirror.database import FlirrorObject, store_object_by_key
 
 LOGGER = logging.getLogger(__name__)
 
@@ -164,16 +164,9 @@ class GoogleOAuth:
 
         return res.json()
 
-    @db_session
-    def _store_access_token(self, token_data):
-        try:
-            # The most common case is to refresh an existing token, so there should
-            # already be an existing database entry that we can update
-            FlirrorObject["google_oauth_token"].value = token_data
-        except ObjectNotFound:
-            # If we request a token for the first time, we don't have an entry in
-            # the database yet and thus have to create one
-            FlirrorObject(key="google_oauth_token", value=token_data)
+    @staticmethod
+    def _store_access_token(token_data):
+        store_object_by_key(key="google_oauth_token", value=token_data)
 
     def _get_oauth_flow(self):
         client_secret_file = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET")

--- a/flirror/database.py
+++ b/flirror/database.py
@@ -71,3 +71,13 @@ def store_object_by_key(key, value):
         # If no entry could be found (e.g. calling a crawler for the first time,
         # requesting an initial access token), we have to create one
         FlirrorObject(key=key, value=value)
+
+
+@db_session
+def get_object_by_key(key):
+    try:
+        return FlirrorObject[key].value
+    except ObjectNotFound:
+        # TODO Log exception, which logger?
+        print("Could not get object with key '{}'".format(key))
+        return None

--- a/flirror/database.py
+++ b/flirror/database.py
@@ -1,6 +1,8 @@
 from pony.orm import (
     Database,
+    db_session,
     Json,
+    ObjectNotFound,
     Optional,
     ormtypes,
     PrimaryKey,
@@ -58,3 +60,14 @@ db.generate_mapping(create_tables=True)
 
 # Activate pony's debug mode
 # set_sql_debug(True)
+
+
+@db_session
+def store_object_by_key(key, value):
+    try:
+        # The most common case is to update an existing entry.
+        FlirrorObject[key].value = value
+    except ObjectNotFound:
+        # If no entry could be found (e.g. calling a crawler for the first time,
+        # requesting an initial access token), we have to create one
+        FlirrorObject(key=key, value=value)

--- a/flirror/database.py
+++ b/flirror/database.py
@@ -45,7 +45,7 @@ class CalendarEvent(db.Entity):
     location = Optional(str, nullable=True)
 
 
-class Misc(db.Entity):
+class FlirrorObject(db.Entity):
     key = PrimaryKey(str)
     value = Required(Json)
 

--- a/flirror/templates/weather.html
+++ b/flirror/templates/weather.html
@@ -26,7 +26,7 @@
             <div class="col-2"></div>
         </div>
         <div class="row">
-            {% for fc in forecasts %}
+            {% for fc in weather.forecasts %}
             <div class="col-2">
                 <p class="small">{{ fc.date.strftime("%a") | upper }}</p>
                 <p><i class="{{ fc.icon | weather_icon }}"></i></p>

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -1,10 +1,11 @@
 import abc
+from datetime import datetime
 
 from flask import current_app, render_template
 from flask.views import MethodView
-from pony.orm import db_session, desc, select
+from pony.orm import db_session, select
 
-from flirror.database import CalendarEvent, Weather
+from flirror.database import CalendarEvent, get_object_by_key
 
 
 class FlirrorMethodView(MethodView):
@@ -54,31 +55,29 @@ class WeatherView(FlirrorMethodView):
     rule = "/weather"
     template_name = "weather.html"
 
+    FLIRROR_OBJECT_KEY = "module_weather"
+
     def get(self):
-        # Get view-specific settings from config
-        settings = current_app.config["MODULES"].get(self.endpoint)
-        city = settings.get("city")
+        # TODO Get view-specific settings from config
+        # settings = current_app.config["MODULES"].get(self.endpoint)
+        # city = settings.get("city")
 
         # Get weather data from database
-        weather, forecasts = self.get_weather(city)
+        weather = self.get_weather()
 
         # Provide weather data in template context
-        context = self.get_context(weather=weather, forecasts=forecasts)
+        context = self.get_context(weather=weather)
         return render_template(self.template_name, **context)
 
-    @db_session
-    def get_weather(self, city):
-        # TODO Get the latest weather entry based on what?
-        # TODO Do we need to check the city at all? There should be only one
-        #  data-crawler per mirror ensuring that the correct data is crawled and
-        #  stored in the database.
-        for weather in select(w for w in Weather if w.city == city).order_by(
-            desc(Weather.date)
-        ):
-            # TODO Simply return the first weather we found
-            # NOTE Directly return the full list of forecasts, because it needs
-            # and active db_session to get it.
-            return weather, list(weather.forecasts)
+    def get_weather(self):
+        weather = get_object_by_key(self.FLIRROR_OBJECT_KEY)
+        # Change timestamps to datetime objects
+        # TODO This should be done before storing the data, but I'm not sure
+        # how to tell Pony how to serialize the datetime to JSON
+        weather["date"] = datetime.utcfromtimestamp(weather["date"])
+        for fc in weather["forecasts"]:
+            fc["date"] = datetime.utcfromtimestamp(fc["date"])
+        return weather
 
 
 class CalendarView(FlirrorMethodView):

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -3,9 +3,8 @@ from datetime import datetime
 
 from flask import current_app, render_template
 from flask.views import MethodView
-from pony.orm import db_session, select
 
-from flirror.database import CalendarEvent, get_object_by_key
+from flirror.database import get_object_by_key
 
 
 class FlirrorMethodView(MethodView):
@@ -86,26 +85,28 @@ class CalendarView(FlirrorMethodView):
     rule = "/calendar"
     template_name = "calendar.html"
 
+    FLIRROR_OBJECT_KEY = "module_calendar"
+
     def get(self):
         # Get view-specific settings from config
         # TODO Do we need to filter for these calendars?
         #  settings = current_app.config["MODULES"].get(self.endpoint)
         #  calendars = settings["calendars"]
 
-        events = self.get_events()
+        data = self.get_events()
         # Provide events in template context
-        context = self.get_context(events=events)
+        context = self.get_context(date=data["date"], events=data["events"])
         return render_template(self.template_name, **context)
 
-    @db_session
     def get_events(self):
-        # Get events from database
-        events = []
-        # TODO How to limit the amount of items to retrieve from the database?
-        #  Use the max_items setting here also?
-        for event in select(e for e in CalendarEvent).order_by(CalendarEvent.start):
-            events.append(event)
-        return events
+        data = get_object_by_key(self.FLIRROR_OBJECT_KEY)
+        # Change timestamps to datetime objects
+        # TODO This should be done before storing the data, but I'm not sure
+        # how to tell Pony how to serialize the datetime to JSON
+        for event in data["events"]:
+            event["start"] = datetime.utcfromtimestamp(event["start"])
+            event["end"] = datetime.utcfromtimestamp(event["end"])
+        return data
 
 
 class MapView(FlirrorMethodView):


### PR DESCRIPTION
When displaying the data on the smartmirror, we are interesting in the
current data set. Storing only the current data set in DB and always
overwrite this with a new one, makes retrieving the data in the view
simpler and doesn't require a cleanup mechanism after a certain time.

Changes:

e71501c (Felix Schmidt, 6 minutes ago)
   Add the long missing .gitignore file

c81f184 (Felix Schmidt, 7 minutes ago)
   Use FlirrorObject to store and retrieve calendar information

db3479a (Felix Schmidt, 3 weeks ago)
   Use FlirrorObject to store and retrieve weather information

462c569 (Felix Schmidt, 3 weeks ago)
   Use store_object_by_key method to store arbitrary FlirrorObjects

fd9d679 (Felix Schmidt, 3 weeks ago)
   Use FlirrorObject class for Google OAuth