### PR TITLE
Fix wrong handling of access and fresh tokens in some cases

### DIFF
--- a/flirror/crawler/crawlers.py
+++ b/flirror/crawler/crawlers.py
@@ -121,11 +121,6 @@ class CalendarCrawler:
         )
 
         try:
-            # TODO Error on initial request (with initial access token):
-            #  ValueError: {'access_token': 'ya29.GltTB4hSMZCww2snLPzpma0Fkq9vriYAjdySDTiSfYdiCKupTczbbv5hwevK4DAV2r7mfXi4wMiV2cmYFSpWyaP3ukHGTUkWPLI3Z2B0YrwxqO4f9ycbS39yj3SS',
-            #  'expires_in': 1564303934.249835, 'refresh_token': '1/OrhaTqqkK349FgaGOwzjSN-j0JxsZfKbNRKyDPS3kzI',
-            #  'scope': 'https://www.googleapis.com/auth/calendar.readonly', 'token_type': 'Bearer'}
-            #  could not be converted to unicode
             calendar_list = service.calendarList().list().execute()
         except RefreshError:
             # Google responds with a RefreshError when the token is invalid as it

--- a/flirror/crawler/crawlers.py
+++ b/flirror/crawler/crawlers.py
@@ -109,6 +109,8 @@ class CalendarCrawler:
 
     def crawl(self):
         credentials = GoogleOAuth(self.SCOPES).get_credentials()
+        if not credentials:
+            raise CrawlerDataError("Unable to authenticate to Google API")
 
         # Get the current time to store in the calender events list in the database
         now = time.time()

--- a/flirror/crawler/google_auth.py
+++ b/flirror/crawler/google_auth.py
@@ -95,7 +95,7 @@ class GoogleOAuth:
             token_data["refresh_token"] = refresh_token
 
         self._store_access_token(token_data)
-        return token_data
+        return token_data["access_token"]
 
     def ask_for_access(self):
         # As the device code is only necessary for the initial token request,


### PR DESCRIPTION
Changes:

12acbe2 (Felix Schmidt, 9 minutes ago)
   Fix wrong return value of refresh_access_token

   In comparison to the other authentication functions, this one returned the
   full token_data dictionary rather than only the access token.

   Using this code path fails the Google authentication, as the whole 
   dictionary cannot be converted to unicode.

100594b (Felix Schmidt, 30 minutes ago)
   Store initial refresh token with every new access token

   It looks like only the initial access token provides a refresh token. All
   access tokens that are requested by using this refresh token, don't provide
   an own refresh token. As we are always overwriting the old access token
   with the new one, we must keep the old refresh token if the new access
   token does not provide one by itself.