### PR TITLE
Initialize application's root logger as "flirror" in crawler package

### DIFF
--- a/flirror/crawler/__init__.py
+++ b/flirror/crawler/__init__.py
@@ -1,4 +1,4 @@
 import logging
 
 # Define root logger for the whole application
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger("flirror")


### PR DESCRIPTION
This way, the configuration of the "flirror" logger also takes effect on
packages which are on the same level like the crawler package because
they are used for both, the crawler and the webserver(e.g. the database
package), but still provide useful log output for the crawler
application.