### PR TITLE
Configure pytest, add tests for Google authentication and improve handling of database connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ database.sqlite
 __pycache__
 build/
 dist/
+htmlcov/
 
 # Development and OS
 .idea

--- a/flirror/__init__.py
+++ b/flirror/__init__.py
@@ -1,6 +1,6 @@
 from flask import Flask
 
-from .database import connect
+from .database import create_database_and_entities
 from .helpers import make_error_handler
 from .utils import weather_icon
 from .views import CalendarView, IndexView, MapView, WeatherView
@@ -32,6 +32,18 @@ def create_app():
     app.add_template_filter(weather_icon)
 
     # Connect to the sqlite database
-    connect(app.config["DATABASE_FILE"])
+    # TODO (felix): Maybe we could drop the 'create_db' here?
+    # Usually, it should be sufficient, when the crawler creates the database. If it
+    # is not created here, we should just provide somee message to start the crawler.
+    db = create_database_and_entities(
+        provider="sqlite", filename=app.config["DATABASE_FILE"], create_db=True
+    )
+
+    # Store the dabase connection in flask's extensions dictionary.
+    # TODO (felix): Is there a better place to store it?
+    if not hasattr(app, "extensions"):
+        app.extensions = {}
+    if "database" not in app.extensions:
+        app.extensions["database"] = db
 
     return app

--- a/flirror/__init__.py
+++ b/flirror/__init__.py
@@ -1,5 +1,6 @@
 from flask import Flask
 
+from .database import connect
 from .helpers import make_error_handler
 from .utils import weather_icon
 from .views import CalendarView, IndexView, MapView, WeatherView
@@ -29,5 +30,8 @@ def create_app():
 
     # Add custom Jinja2 template filters
     app.add_template_filter(weather_icon)
+
+    # Connect to the sqlite database
+    connect(app.config["DATABASE_FILE"])
 
     return app

--- a/flirror/__init__.py
+++ b/flirror/__init__.py
@@ -31,6 +31,3 @@ def create_app():
     app.add_template_filter(weather_icon)
 
     return app
-
-
-app = create_app()

--- a/flirror/crawler/crawlers.py
+++ b/flirror/crawler/crawlers.py
@@ -19,7 +19,8 @@ class WeatherCrawler:
 
     FLIRROR_OBJECT_KEY = "module_weather"
 
-    def __init__(self, api_key, language, city, temp_unit):
+    def __init__(self, database, api_key, language, city, temp_unit):
+        self.database = database
         self.api_key = api_key
         self.language = language
         self.city = city
@@ -47,7 +48,9 @@ class WeatherCrawler:
             fc_data = self._parse_forecast_data(fc_weather, self.temp_unit)
             weather_data["forecasts"].append(fc_data)
 
-        store_object_by_key(key=self.FLIRROR_OBJECT_KEY, value=weather_data)
+        store_object_by_key(
+            self.database, key=self.FLIRROR_OBJECT_KEY, value=weather_data
+        )
 
     @property
     def owm(self):
@@ -103,12 +106,13 @@ class CalendarCrawler:
 
     SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
 
-    def __init__(self, calendars, max_items=DEFAULT_MAX_ITEMS):
+    def __init__(self, database, calendars, max_items=DEFAULT_MAX_ITEMS):
+        self.database = database
         self.calendars = calendars
         self.max_items = max_items
 
     def crawl(self):
-        credentials = GoogleOAuth(self.SCOPES).get_credentials()
+        credentials = GoogleOAuth(self.database, self.SCOPES).get_credentials()
         if not credentials:
             raise CrawlerDataError("Unable to authenticate to Google API")
 
@@ -176,7 +180,9 @@ class CalendarCrawler:
         all_events = sorted(all_events, key=lambda k: k["start"])
 
         event_data = {"date": now, "events": all_events[: self.max_items]}
-        store_object_by_key(key=self.FLIRROR_OBJECT_KEY, value=event_data)
+        store_object_by_key(
+            self.database, key=self.FLIRROR_OBJECT_KEY, value=event_data
+        )
 
     @staticmethod
     def _parse_event_data(event):

--- a/flirror/crawler/google_auth.py
+++ b/flirror/crawler/google_auth.py
@@ -156,6 +156,7 @@ class GoogleOAuth:
                 )
                 # Should be around 5 secs
                 time.sleep(device["interval"])
+        raise GoogleOAuthError("Device is expired, please restart the application.")
 
     def _request_initial_access_token(self, device):
         # Use the device code for an initial token request

--- a/flirror/crawler/google_auth.py
+++ b/flirror/crawler/google_auth.py
@@ -20,7 +20,9 @@ class GoogleOAuth:
     # We could use the class object to store the active token in the session
     # and check this one first for expiry, before retrieving a new one and store
     # that in the database and session.
-    def __init__(self, scopes):
+    def __init__(self, scopes=None):
+        if scopes is None:
+            scopes = []
         self.scopes = scopes
 
     def get_credentials(self):

--- a/flirror/crawler/google_auth.py
+++ b/flirror/crawler/google_auth.py
@@ -20,10 +20,11 @@ class GoogleOAuth:
     # We could use the class object to store the active token in the session
     # and check this one first for expiry, before retrieving a new one and store
     # that in the database and session.
-    def __init__(self, scopes=None):
+    def __init__(self, database, scopes=None):
         if scopes is None:
             scopes = []
         self.scopes = scopes
+        self.database = database
 
     def get_credentials(self):
         token = self.authenticate()
@@ -49,7 +50,7 @@ class GoogleOAuth:
 
         # The most common case is to refresh an existing token, so there should
         # already be an existing database entry that we can update
-        token_obj = get_object_by_key("google_oauth_token")
+        token_obj = get_object_by_key(self.database, "google_oauth_token")
         if token_obj is None:
             LOGGER.debug("Could not find any access token. Requesting an initial one.")
             token = self.ask_for_access()
@@ -173,9 +174,8 @@ class GoogleOAuth:
 
         return res.json()
 
-    @staticmethod
-    def _store_access_token(token_data):
-        store_object_by_key(key="google_oauth_token", value=token_data)
+    def _store_access_token(self, token_data):
+        store_object_by_key(self.database, key="google_oauth_token", value=token_data)
 
     def _get_oauth_flow(self):
         client_secret_file = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET")

--- a/flirror/crawler/main.py
+++ b/flirror/crawler/main.py
@@ -6,6 +6,7 @@ from flask.config import Config
 
 from flirror import FLIRROR_SETTINGS_ENV
 from flirror.crawler.crawlers import CalendarCrawler, WeatherCrawler
+from flirror.database import connect
 
 
 LOGGER = logging.getLogger(__name__)
@@ -61,6 +62,9 @@ def crawl(ctx):
     LOGGER.info("Hello, Flirror!")
 
     config = ctx.obj["config"]
+
+    # Connect to the sqlite database
+    connect(config["DATABASE_FILE"])
 
     # TODO Look up crawlers from config file
     for name, crawler_cls in [

--- a/flirror/crawler/main.py
+++ b/flirror/crawler/main.py
@@ -6,7 +6,7 @@ from flask.config import Config
 
 from flirror import FLIRROR_SETTINGS_ENV
 from flirror.crawler.crawlers import CalendarCrawler, WeatherCrawler
-from flirror.database import connect
+from flirror.database import create_database_and_entities
 
 
 LOGGER = logging.getLogger(__name__)
@@ -64,7 +64,9 @@ def crawl(ctx):
     config = ctx.obj["config"]
 
     # Connect to the sqlite database
-    connect(config["DATABASE_FILE"])
+    db = create_database_and_entities(
+        provider="sqlite", filename=config["DATABASE_FILE"], create_db=True
+    )
 
     # TODO Look up crawlers from config file
     for name, crawler_cls in [
@@ -72,7 +74,7 @@ def crawl(ctx):
         ("calendar", CalendarCrawler),
     ]:
         settings = config["MODULES"].get(name)
-        crawler = crawler_cls(**settings)
+        crawler = crawler_cls(database=db, **settings)
         crawler.crawl()
 
 

--- a/flirror/database.py
+++ b/flirror/database.py
@@ -5,41 +5,46 @@ from pony.orm import Database, db_session, Json, ObjectNotFound, PrimaryKey, Req
 
 LOGGER = logging.getLogger(__name__)
 
-db = Database()
 
+# How to use separated databases for prod and testing:
+# https://github.com/ponyorm/pony/issues/32
+def create_database_and_entities(**db_params):
+    db = Database()
 
-class FlirrorObject(db.Entity):
-    key = PrimaryKey(str)
-    value = Required(Json)
+    class FlirrorObject(db.Entity):
+        key = PrimaryKey(str)
+        value = Required(Json)
+
+    LOGGER.debug(
+        "Creating new database connection with the following parameters: %s", db_params
+    )
+    # Connect to the database and create it if it doesn't exist
+    db.bind(**db_params)
+
+    # Create the tables if they don't exist
+    db.generate_mapping(create_tables=True)
+
+    return db
 
 
 @db_session
-def store_object_by_key(key, value):
+def store_object_by_key(db, key, value):
     try:
         LOGGER.debug("Updating object with key '%s' in database", key)
         # The most common case is to update an existing entry.
-        FlirrorObject[key].value = value
+        db.FlirrorObject[key].value = value
     except ObjectNotFound:
         LOGGER.debug("Object with key '%s' not found, creating a new one", key)
         # If no entry could be found (e.g. calling a crawler for the first time,
         # requesting an initial access token), we have to create one
-        FlirrorObject(key=key, value=value)
+        db.FlirrorObject(key=key, value=value)
 
 
 @db_session
-def get_object_by_key(key):
+def get_object_by_key(db, key):
     try:
         LOGGER.debug("Getting object with key '%s' from database", key)
-        return FlirrorObject[key].value
+        return db.FlirrorObject[key].value
     except ObjectNotFound:
         LOGGER.error("Could not get object with key '%s'", key)
         return None
-
-
-def connect(database_file):
-    LOGGER.debug("Using database file '%s'", database_file)
-    # Connect to the database and create it if it doesn't exist
-    db.bind(provider="sqlite", filename=database_file, create_db=True)
-
-    # Create the tables if they don't exist
-    db.generate_mapping(create_tables=True)

--- a/flirror/database.py
+++ b/flirror/database.py
@@ -13,13 +13,6 @@ class FlirrorObject(db.Entity):
     value = Required(Json)
 
 
-# Connect to the database and create it if it doesn't exist
-db.bind(provider="sqlite", filename="database.sqlite", create_db=True)
-
-# Create the tables if they don't exist
-db.generate_mapping(create_tables=True)
-
-
 @db_session
 def store_object_by_key(key, value):
     try:
@@ -41,3 +34,12 @@ def get_object_by_key(key):
     except ObjectNotFound:
         LOGGER.error("Could not get object with key '%s'", key)
         return None
+
+
+def connect(database_file):
+    LOGGER.debug("Using database file '%s'", database_file)
+    # Connect to the database and create it if it doesn't exist
+    db.bind(provider="sqlite", filename=database_file, create_db=True)
+
+    # Create the tables if they don't exist
+    db.generate_mapping(create_tables=True)

--- a/flirror/exceptions.py
+++ b/flirror/exceptions.py
@@ -2,3 +2,9 @@ class CrawlerDataError(Exception):
     """Exception if some data could not be retrieved by a crawler."""
 
     pass
+
+
+class GoogleOAuthError(Exception):
+    """Exception if the Google OAuth authencitaion failed."""
+
+    pass

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -69,7 +69,8 @@ class WeatherView(FlirrorMethodView):
         return render_template(self.template_name, **context)
 
     def get_weather(self):
-        weather = get_object_by_key(self.FLIRROR_OBJECT_KEY)
+        db = current_app.extensions["database"]
+        weather = get_object_by_key(db, self.FLIRROR_OBJECT_KEY)
         # Change timestamps to datetime objects
         # TODO This should be done before storing the data, but I'm not sure
         # how to tell Pony how to serialize the datetime to JSON
@@ -99,7 +100,8 @@ class CalendarView(FlirrorMethodView):
         return render_template(self.template_name, **context)
 
     def get_events(self):
-        data = get_object_by_key(self.FLIRROR_OBJECT_KEY)
+        db = current_app.extensions["database"]
+        data = get_object_by_key(db, self.FLIRROR_OBJECT_KEY)
         # Change timestamps to datetime objects
         # TODO This should be done before storing the data, but I'm not sure
         # how to tell Pony how to serialize the datetime to JSON

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -1,6 +1,9 @@
 # The sercret key for the flask application, see
 # http://flask.pocoo.org/docs/1.0/quickstart/#sessions
-SECRET_KEY = "_5#y2L"F4Q8z\n\xec]/"
+SECRET_KEY = '_5#y2L"F4Q8z\n\xec]/'
+
+DATABASE_FILE = "database.sqlite"
+
 MODULES = {
     "weather": {
         # Where to retrieve the weather data for

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from flirror.database import connect
+from flirror.database import create_database_and_entities
 
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "testdata")
 
@@ -16,6 +16,9 @@ def mock_google_env(monkeypatch):
 
 @pytest.fixture(scope="function")
 def mock_database(tmpdir):
-    connect(os.path.join(tmpdir, "test_database.sqlite"))
-    yield
-    # TODO Delete database?
+    database_file = os.path.join(tmpdir, "test_database.sqlite")
+    db = create_database_and_entities(
+        provider="sqlite", filename=database_file, create_db=True
+    )
+    yield db
+    db.disconnect()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+
+import pytest
+
+FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "testdata")
+
+
+@pytest.fixture(scope="function")
+def mock_google_env(monkeypatch):
+    monkeypatch.setenv(
+        "GOOGLE_OAUTH_CLIENT_SECRET", os.path.join(FIXTURE_DIR, "client_secret.json")
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from flirror.database import connect
+
 FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "testdata")
 
 
@@ -10,3 +12,10 @@ def mock_google_env(monkeypatch):
     monkeypatch.setenv(
         "GOOGLE_OAUTH_CLIENT_SECRET", os.path.join(FIXTURE_DIR, "client_secret.json")
     )
+
+
+@pytest.fixture(scope="function")
+def mock_database(tmpdir):
+    connect(os.path.join(tmpdir, "test_database.sqlite"))
+    yield
+    # TODO Delete database?

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -1,7 +1,9 @@
 import os
 import time
+from unittest import mock
 
 import pytest
+import requests
 import requests_mock
 from freezegun import freeze_time
 
@@ -47,6 +49,92 @@ def test_refresh_access_token(mock_google_env, mock_database):
             "scope": "https://www.googleapis.com/auth/calendar.readonly",
             "token_type": "Bearer",
         }
+
+
+def test_request_initial_access_token(mock_google_env):
+    goauth = GoogleOAuth()
+
+    device = {
+        "device_code": "device_code",
+        "verification_url": "some-google-device-url",
+        "expires_in": 3600,
+        "user_code": "ABCD-EFGH",
+    }
+
+    expected_data = {
+        "access_token": "initial_access_token",
+        "refresh_token": "refresh_token",
+        "expires_in": 3600,
+        # TODO (felix): What else?
+        "token_type": "Bearer",
+    }
+
+    with requests_mock.mock() as m:
+        m.post(goauth.GOOGLE_OAUTH_POLL_URL, json=expected_data)
+
+        token_data = goauth._request_initial_access_token(device)
+        assert token_data == expected_data
+
+
+@freeze_time("2019-08-21 00:00:00")
+def test_poll_for_initial_access_token(mock_google_env):
+    goauth = GoogleOAuth()
+
+    device = {
+        "device_code": "device_code",
+        "verification_url": "some-google-device-url",
+        "expires_in": time.time() + 3600,
+        "user_code": "ABCD-EFGH",
+    }
+
+    with mock.patch.object(
+        goauth, "_request_initial_access_token", return_value={"expires_in": 3600}
+    ):
+        token_data = goauth.poll_for_initial_access_token(device)
+    assert token_data == {"expires_in": time.time() + 3600}
+
+
+@freeze_time("2019-08-21 00:00:00")
+def test_poll_for_initial_access_token_expired(mock_google_env):
+    goauth = GoogleOAuth()
+
+    device = {"expires_in": time.time() - 3600}
+
+    with pytest.raises(GoogleOAuthError) as excinfo:
+        goauth.poll_for_initial_access_token(device)
+
+    assert "Device is expired, please restart the application." == str(excinfo.value)
+
+
+@freeze_time("2019-08-21 00:00:00", auto_tick_seconds=15)
+def test_poll_for_initial_access_token_retry(mock_google_env):
+    # TODO Release and recreate database connection between tests
+    goauth = GoogleOAuth()
+
+    # Mock the device with a 0 interval, so we don't actively wait between the calls
+    # in this test.
+    device = {"expires_in": time.time() + 3600, "interval": 0}
+
+    side_effects = [
+        requests.exceptions.HTTPError,
+        requests.exceptions.HTTPError,
+        {"expires_in": 3600},
+    ]
+
+    # Mock the first two responses to return errors, on the third call we will
+    # get a result
+    with mock.patch.object(
+        goauth, "_request_initial_access_token", side_effect=side_effects
+    ) as req_mock:
+        goauth.poll_for_initial_access_token(device)
+
+    # Ensure that the req_mock method was called three times (two failures, one success)
+    # with the actual device parameters
+    assert req_mock.call_args_list == [
+        mock.call(device),
+        mock.call(device),
+        mock.call(device),
+    ]
 
 
 def test_get_oauth_flow(mock_google_env):

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -12,7 +12,7 @@ from flirror.exceptions import GoogleOAuthError
 
 @freeze_time("2019-08-21 00:00:00")
 def test_refresh_access_token(mock_google_env, mock_database):
-    goauth = GoogleOAuth(scopes=[])
+    goauth = GoogleOAuth()
     with requests_mock.mock() as m:
         m.post(
             goauth.GOOGLE_OAUTH_POLL_URL,
@@ -50,7 +50,7 @@ def test_refresh_access_token(mock_google_env, mock_database):
 
 
 def test_get_oauth_flow(mock_google_env):
-    goauth = GoogleOAuth(scopes=[])
+    goauth = GoogleOAuth()
 
     flow = goauth._get_oauth_flow()
     assert flow.client_config["client_id"] == "test_client_id"
@@ -58,7 +58,7 @@ def test_get_oauth_flow(mock_google_env):
 
 
 def test_get_oauth_flow_missing():
-    goauth = GoogleOAuth(scopes=[])
+    goauth = GoogleOAuth()
 
     # Ensure that a exception is raised because no GOOGLE_OAUTH_CLIENT_SECRET
     # envvar is set
@@ -71,7 +71,7 @@ def test_get_oauth_flow_missing():
 
 
 def test_get_oauth_flow_invalid():
-    goauth = GoogleOAuth(scopes=[])
+    goauth = GoogleOAuth()
 
     os.environ["GOOGLE_OAUTH_CLIENT_SECRET"] = "invalid_client_secret_file"
 

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -1,0 +1,30 @@
+import requests_mock
+
+from flirror.crawler.google_auth import GoogleOAuth
+
+
+def test_refresh_access_token(mock_google_env):
+    goauth = GoogleOAuth(scopes=[])
+    with requests_mock.mock() as m:
+        m.post(
+            goauth.GOOGLE_OAUTH_POLL_URL,
+            json={
+                "access_token": "some_access_token",
+                "expires_in": 3600,
+                "scope": "https://www.googleapis.com/auth/calendar.readonly",
+                "token_type": "Bearer",
+            },
+        )
+
+        access_token = goauth.refresh_access_token("refresh_token")
+
+        assert access_token == "some_access_token"
+        # Ensure that the request parameters were build correctly
+        # TODO (felix): Could we also validate the request's data attribute
+        # directly, rather than the concatenated text?
+        assert m.last_request.text == (
+            "client_id=test_client_id"
+            "&client_secret=test_client_secret"
+            "&refresh_token=refresh_token"
+            "&grant_type=refresh_token"
+        )

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -239,6 +239,11 @@ def test_get_oauth_flow(mock_google_env):
 def test_get_oauth_flow_missing():
     goauth = GoogleOAuth(database=None)
 
+    # NOTE (felix): Ensure the variable is missing in the environment
+    # (e.g. in case the test is not executed from a clean tox env but directly
+    # in the user's env).
+    os.unsetenv("GOOGLE_OAUTH_CLIENT_SECRET")
+
     # Ensure that a exception is raised because no GOOGLE_OAUTH_CLIENT_SECRET
     # envvar is set
     with pytest.raises(GoogleOAuthError) as excinfo:

--- a/tests/testdata/client_secret.json
+++ b/tests/testdata/client_secret.json
@@ -1,0 +1,14 @@
+{
+    "installed": {
+        "client_id": "test_client_id",
+        "project_id": "test_project_id",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_secret": "test_client_secret",
+        "redirect_uris": [
+            "urn:ietf:wg:oauth:2.0:oob",
+            "http://localhost"
+        ]
+    }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ commands =
     flake8
     black --check --diff .
     python setup.py sdist bdist_wheel
+    flirror-crawler --help
 
 [testenv:dev]
 description = Development environment for Flirror

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ description = Running static code checks and unit tests
 deps =
     flake8
     black
+    freezegun
     pytest
     pytest-cov
     requests-mock

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,18 @@
 envlist = py36, dev
 
 [testenv]
-description = Running static code checks
+description = Running static code checks and unit tests
 deps =
     flake8
     black
+    pytest
+    pytest-cov
 commands =
+    # We must call pytest as module to make the coverage report work.
+    # Otherwise, the coverage will always be 0%.
+    {envpython} -m pytest \
+        --cov=flirror --cov-report=term --cov-report=html --cov-report=xml \
+        --verbose {posargs}
     flake8
     black --check --diff .
     python setup.py sdist bdist_wheel

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     black
     pytest
     pytest-cov
+    requests-mock
 commands =
     # We must call pytest as module to make the coverage report work.
     # Otherwise, the coverage will always be 0%.

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
     # We must call pytest as module to make the coverage report work.
     # Otherwise, the coverage will always be 0%.
     {envpython} -m pytest \
-        --cov=flirror --cov-report=term --cov-report=html --cov-report=xml \
+        --cov=flirror --cov-report=term-missing --cov-report=html --cov-report=xml \
         --verbose {posargs}
     flake8
     black --check --diff .


### PR DESCRIPTION
Changes:

41a414a (Felix Schmidt, 73 seconds ago)
   Fix test_get_oauth_flow_missing test to work with a clean environment

20960da (Felix Schmidt, 33 minutes ago)
   Add tests for remaining GoogleOAuth methods

eafbcb1 (Felix Schmidt, 7 days ago)
   Let pytest-coverage report missing lines in terminal

84dd99d (Felix Schmidt, 7 days ago)
   Use dedicated database instances for testing

   Although the connection was configurable before, it couldn't be used 
   effectively for testing as the object behind the database was still the 
   same and thus could not simply be teared down and set up again for each 
   test. Therefore, this change explicitly creates dedicated Database
   instances, so there is no magic "db" object that is used in the background
   for every transaction. The drawback of this is, that the database must now
   be provided for each transaction and such, every component working with the
   database needs to know about it.

117a041 (Felix Schmidt, 7 days ago)
   Add tests for initial access token request/poll

e14303e (Felix Schmidt, 7 days ago)
   Simplify initialization of GoogleOAuth class in tests

4ffe381 (Felix Schmidt, 10 days ago)
   Add tests for Google OAuth flow creation

6e030bd (Felix Schmidt, 10 days ago)
   Test flirror-crawler command in tox.ini

c138c33 (Felix Schmidt, 10 days ago)
   Cover database transaction in google oauth token refresh test

2095e36 (Felix Schmidt, 10 days ago)
   Make database connection configurable

   This allows us to use a different database file for testing.

5364045 (Felix Schmidt, 10 days ago)
   Add tests for google oauth token refresh

3aaec1e (Felix Schmidt, 2 weeks ago)
   Run pytest with coverage in tox test env