### PR TITLE
Allow direct crawling of single modules and make peridic crawling configurable

### DIFF
--- a/flirror/crawler/main.py
+++ b/flirror/crawler/main.py
@@ -59,8 +59,12 @@ def main(ctx, verbosity):
         ctx.invoke(crawl)
 
 
+@main.command()
+@click.option(
+    "--module", "-m", help="Crawl only the module with the specified ID", multiple=True
+)
 @click.pass_context
-def crawl(ctx):
+def crawl(ctx, module):
     LOGGER.info("Hello, Flirror!")
 
     config = ctx.obj["config"]
@@ -73,8 +77,14 @@ def crawl(ctx):
     # Create the crawler factory to use for initializing new crawlers
     factory = CrawlerFactory()
 
+    if module:
+        # Filter crawlers for provided module IDs
+        crawler_configs = {m: config.get("MODULES", {}).get(m) for m in module}
+    else:
+        crawler_configs = config.get("MODULES", {})
+
     # Look up crawlers from config file
-    for crawler_id, crawler_config in config.get("MODULES", {}).items():
+    for crawler_id, crawler_config in crawler_configs.items():
         crawler_type = crawler_config.pop("type")
         # TODO Error handling for wrong/missing keys
         LOGGER.info(

--- a/tests/crawler/test_scheduling.py
+++ b/tests/crawler/test_scheduling.py
@@ -5,7 +5,7 @@ from flirror.crawler.crawlers import Crawler
 from flirror.crawler.scheduling import Scheduler
 
 
-class TestCrawler(Crawler):
+class DummyCrawler(Crawler):
     def __init__(self, interval):
         super().__init__(crawler_id="test", database=None, interval=interval)
 
@@ -16,10 +16,10 @@ class TestCrawler(Crawler):
 
 @mock.patch.object(flirror.crawler.scheduling, "schedule")
 def test_add_job(schedule_mock):
-    crawler_30s = TestCrawler(interval="30s")
-    crawler_5m = TestCrawler(interval="5m")
-    crawler_10m = TestCrawler(interval="10m")
-    crawler_1h = TestCrawler(interval="1h")
+    crawler_30s = DummyCrawler(interval="30s")
+    crawler_5m = DummyCrawler(interval="5m")
+    crawler_10m = DummyCrawler(interval="10m")
+    crawler_1h = DummyCrawler(interval="1h")
 
     scheduler = Scheduler()
     scheduler.add_job(crawler_30s)


### PR DESCRIPTION
Changes:

aaa7985 (Felix Schmidt, 3 minutes ago)
   Fix pytest warning "cannot collect test class 'TestCrawler'"

   PytestCollectionWarning: cannot collect test class 'TestCrawler' because it
   has a __init__ constructor (from:
      tests/crawler/test_scheduling.py)
        class TestCrawler(Crawler):

0949970 (Felix Schmidt, 7 minutes ago)
   Make periodic option configurable

eea7b8e (Felix Schmidt, 24 minutes ago)
   Allow crawling of single modules

   Specify a single (or multiple) modules via the -m option.