### PR TITLE
Allow using the same module multiple times with different configuration

### DIFF
--- a/flirror/crawler/crawlers.py
+++ b/flirror/crawler/crawlers.py
@@ -24,6 +24,10 @@ class Crawler:
         self.database = database
         self.interval = interval
 
+    @property
+    def object_key(self):
+        return f"{self.FLIRROR_OBJECT_KEY}-{self.id}"
+
 
 class WeatherCrawler(Crawler):
 
@@ -64,9 +68,7 @@ class WeatherCrawler(Crawler):
         # Store the crawl timestamp
         weather_data["_timestamp"] = now
 
-        store_object_by_key(
-            self.database, key=self.FLIRROR_OBJECT_KEY, value=weather_data
-        )
+        store_object_by_key(self.database, key=self.object_key, value=weather_data)
 
     @property
     def owm(self):
@@ -203,9 +205,7 @@ class CalendarCrawler(Crawler):
         all_events = sorted(all_events, key=lambda k: k["start"])
 
         event_data = {"_timestamp": now, "events": all_events[: self.max_items]}
-        store_object_by_key(
-            self.database, key=self.FLIRROR_OBJECT_KEY, value=event_data
-        )
+        store_object_by_key(self.database, key=self.object_key, value=event_data)
 
     @staticmethod
     def _parse_event_data(event):
@@ -305,9 +305,7 @@ class StocksCrawler(Crawler):
                 # '2. Symbol': 'GOOGL', '3. Last Refreshed': '2019-10-04 16:00:00',
                 # '4. Interval': '15min', '5. Output Size': 'Compact', '6. Time Zone': 'US/Eastern'}
 
-        store_object_by_key(
-            self.database, key=self.FLIRROR_OBJECT_KEY, value=stocks_data
-        )
+        store_object_by_key(self.database, key=self.object_key, value=stocks_data)
 
 
 class CrawlerFactory:

--- a/flirror/templates/error.html
+++ b/flirror/templates/error.html
@@ -1,0 +1,12 @@
+{% extends "layout.html" %}
+
+{% block body %}
+<div class="container">
+    <div class="card bg-dark text-white text-center">
+        <h1><i class="fas fa-sad-tear"></i> Error {{ error_code }}</h1>
+        <blockquote class="blockquote">
+           {{ error_message }}
+        </blockquote>
+    </div>
+</div>
+{% endblock %}

--- a/flirror/templates/module.html
+++ b/flirror/templates/module.html
@@ -1,9 +1,9 @@
 <div class="card dark">
     {% if module.error %}
     <div class="card-body text-center">
-        <h1 class="error"><i class="fas fa-sad-tear"></i> Error {{ error_code }}</h1>
+        <h1 class="error"><i class="fas fa-sad-tear"></i> Error {{ module.error.code }}</h1>
         <p class="card-text">
-           {{ module.error }}
+           {{ module.error.msg }}
         </p>
     </div>
     {% else %}

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -54,7 +54,10 @@ class IndexView(FlirrorMethodView):
             data = None
             error = None
             try:
-                res = requests.get(url_for(f"api-{module_type}", _external=True))
+                res = requests.get(
+                    url_for(f"api-{module_type}", _external=True),
+                    params={"module_id": module_id},
+                )
                 # TODO Error handling?
                 # Add the error message as module data, so it could be displayed with
                 # a general module-error template that can be included in the module.html

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -51,6 +51,7 @@ class IndexView(FlirrorMethodView):
             module_type = module_config.get("type")
             # TODO Error handling for wrong/missing keys
 
+            data = None
             error = None
             try:
                 res = requests.get(url_for(f"api-{module_type}", _external=True))
@@ -58,10 +59,15 @@ class IndexView(FlirrorMethodView):
                 # Add the error message as module data, so it could be displayed with
                 # a general module-error template that can be included in the module.html
                 # in case this error field is set.
-                res.raise_for_status
                 data = res.json()
-            except werkzeug.routing.BuildError as e:
-                error = str(e)
+                res.raise_for_status()
+            except (werkzeug.routing.BuildError, requests.exceptions.HTTPError) as e:
+                msg = str(e)
+                # If we got a better message from the e.g. JSON API, we use it instead
+                if data is not None and "error" in data:
+                    msg = data["msg"]
+
+                error = {"code": res.status_code, "msg": msg}
 
             all_data["modules"][module_id] = {
                 "config": module_config,

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -5,7 +5,8 @@ SECRET_KEY = '_5#y2L"F4Q8z\n\xec]/'
 DATABASE_FILE = "database.sqlite"
 
 MODULES = {
-    "weather": {
+    "weather-hometown": {
+        "type": "weather",
         # Where to retrieve the weather data for
         "city": "My hometown",
         # The API key to access openweathermap
@@ -16,16 +17,27 @@ MODULES = {
         "temp_unit": "celsius",
         "interval": "30s",
     },
-    "calendar": {
+    "calendar-personal": {
+        "type": "calendar",
         "calendars": ["contacts", "<my-account>@googlemail.com"],
         "max_items": 5,
         "interval": "1m",
     },
-    "map": {
-        "api_key": "kfaskldf89adfjaskldgjo9a",
-        "route": {
-            "from": "A",
-            "to": "B",
-        },
+    "stocks-series": {
+        "type": "stocks",
+        "mode": "series",
+        "api_key": "askjfasg89safa",
+        "symbols": [
+            ("GOOGL", "GOOGLE"),
+        ]
+    },
+    "stocks-table": {
+        "type": "stocks",
+        "mode": "table",
+        "api_key": "askjfasg89safa",
+        "symbols": [
+            ("GOOGL", ""),
+            ("aapl", "APPLE"),
+        ]
     },
 }


### PR DESCRIPTION
Changes:

0245e03 (Felix Schmidt, 21 seconds ago)
   Update settings example file

17efa99 (Felix Schmidt, 11 minutes ago)
   Provide module_id parameter to API endpoints in index view

fca5ee5 (Felix Schmidt, 36 minutes ago)
   Recreate error template (which got accidentially deleted)

e2cff60 (Felix Schmidt, 36 minutes ago)
   Fix error handling in index view

df878e9 (Felix Schmidt, 45 minutes ago)
   Provide module_id to API endpoints via GET parameter

   This way, each API endpoint can be used for multiple tiles of the same 
   type.

821ccab (Felix Schmidt, 62 minutes ago)
   Use module id as key for storing data from crawlers