### PR TITLE
Allow multiple modules per position via bootstrap carousel

### DIFF
--- a/flirror/static/css/style.css
+++ b/flirror/static/css/style.css
@@ -1,3 +1,4 @@
+/* General */
 body {
     font-family: Roboto,sans-serif;
     background-color: #121212;
@@ -34,6 +35,17 @@ body {
 
 .error {
     color: #E57373;
+}
+
+/* Carousel */
+.carousel-indicators {
+    bottom: -20px;
+}
+
+.carousel-indicators li {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
 }
 
 /* Weather */

--- a/flirror/templates/index.html
+++ b/flirror/templates/index.html
@@ -7,7 +7,7 @@
             {# Check if we have more than one module for this position,
             and if so use a carousel to show all in one place #}
             {% if modules | length > 1 %}
-            <div class="col-6">
+            <div class="col-6 d-flex align-items-stretch">
                 <div id="carousel-{{ position }}" class="carousel slide" data-ride="carousel">
                     <ol class="carousel-indicators">
                         {% for module in modules %}

--- a/flirror/templates/index.html
+++ b/flirror/templates/index.html
@@ -5,7 +5,7 @@
     <div class="row">
         {% for module_id, module in modules.items() %}
         <div class="col-6">
-            {% include "modules/" + module.config.type + ".html" ignore missing %}
+            {% include "modules/" + module.type + ".html" ignore missing %}
         </div>
         {% endfor %}
     </div>

--- a/flirror/templates/index.html
+++ b/flirror/templates/index.html
@@ -18,7 +18,7 @@
                     </ol>
                     <div class="carousel-inner">
                         {% for module in modules %}
-                        <div class="carousel-item {% if loop.first %}active{% endif %}" data-interval="5000">
+                        <div class="carousel-item {% if loop.first %}active{% endif %}" data-interval="{{ module.display.get('time', 5000) }}">
                             {% include "modules/" + module.type + ".html" ignore missing %}
                         </div>
                         {% endfor %}

--- a/flirror/templates/index.html
+++ b/flirror/templates/index.html
@@ -3,10 +3,35 @@
 {% block body %}
 <div class="pt-4">
     <div class="row">
-        {% for module_id, module in modules.items() %}
-        <div class="col-6">
-            {% include "modules/" + module.type + ".html" ignore missing %}
-        </div>
+        {% for position, modules in modules.items() %}
+            {# Check if we have more than one module for this position,
+            and if so use a carousel to show all in one place #}
+            {% if modules | length > 1 %}
+            <div class="col-6">
+                <div id="carousel-{{ position }}" class="carousel slide" data-ride="carousel">
+                    <ol class="carousel-indicators">
+                        {% for module in modules %}
+                        <li data-target="#carousel-{{ position }}" data-slide-to="{{ loop.index }}"
+                            class="{% if loop.first %}active{% endif %}">
+                        </li>
+                        {% endfor %}
+                    </ol>
+                    <div class="carousel-inner">
+                        {% for module in modules %}
+                        <div class="carousel-item {% if loop.first %}active{% endif %}" data-interval="5000">
+                            {% include "modules/" + module.type + ".html" ignore missing %}
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+            {% else %}
+                {% for module in modules %}
+                <div class="col-6">
+                    {% include "modules/" + module.type + ".html" ignore missing %}
+                </div>
+                {% endfor %}
+            {% endif %}
         {% endfor %}
     </div>
 </div>

--- a/flirror/templates/modules/stocks.html
+++ b/flirror/templates/modules/stocks.html
@@ -8,14 +8,14 @@
         </small>
     </div>
     {% if module.config.mode == "series" %}
-    <canvas id="chart-{{ module_id }}" width="400" height="400"></canvas>
+    <canvas id="chart-{{ module.id }}" width="400" height="400"></canvas>
     {# NOTE: Moment.js must be included before Chart.js to make the time axis work #}
     <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js"
         integrity="sha256-Uv9BNBucvCPipKQ2NS9wYpJmi8DTOEfTA/nH2aoJALw=" crossorigin="anonymous">
     </script>
     <script>
-        var ctx = document.getElementById("chart-{{ module_id }}").getContext("2d");
+        var ctx = document.getElementById("chart-{{ module.id }}").getContext("2d");
         var myChart = new Chart(ctx, {
             type: "line",
             data: {

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -49,18 +49,15 @@ class IndexView(FlirrorMethodView):
         # Here we have also place for overall meta data (like flirror version or so)
         ctx_data = {"modules": defaultdict(list)}
 
-        # Group modules by position and sort positions in asc order
         config_modules = current_app.config.get("MODULES", [])
 
+        # Group modules by position and sort positions in asc order
         pos_modules = defaultdict(list)
         for module in config_modules:
-            pos_modules[module["position"]].append(module)
-
+            pos_modules[module["display"]["position"]].append(module)
         sort_pos_modules = OrderedDict(sorted(pos_modules.items()))
 
         for position, module_configs in sort_pos_modules.items():
-            # TODO Check if the actual positions contains more than a single element
-            # and if so, use a carousel/slide with each module
             for module_config in module_configs:
                 module_id = module_config.get("id")
                 module_type = module_config.get("type")
@@ -91,6 +88,7 @@ class IndexView(FlirrorMethodView):
                         "type": module_type,
                         "id": module_id,
                         "config": module_config["config"],
+                        "display": module_config["display"],
                         "data": data,
                         "error": error,
                     }

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -47,7 +47,10 @@ class IndexView(FlirrorMethodView):
         # Here we have place for overall meta data (like flirror version or so)
         all_data = {"modules": {}}
 
-        for module_id, module_config in current_app.config.get("MODULES", {}).items():
+        config_modules = current_app.config.get("MODULES", [])
+
+        for module_config in config_modules:
+            module_id = module_config.get("id")
             module_type = module_config.get("type")
             # TODO Error handling for wrong/missing keys
 
@@ -73,12 +76,12 @@ class IndexView(FlirrorMethodView):
                 error = {"code": res.status_code, "msg": msg}
 
             all_data["modules"][module_id] = {
-                "config": module_config,
+                "type": module_type,
+                "config": module_config["config"],
                 "data": data,
                 "error": error,
             }
 
-        print(all_data)
         context = self.get_context(**all_data)
         return render_template(self.template_name, **context)
 

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -1,4 +1,5 @@
 import abc
+from collections import defaultdict, OrderedDict
 
 import requests
 import werkzeug
@@ -47,40 +48,46 @@ class IndexView(FlirrorMethodView):
         # Here we have place for overall meta data (like flirror version or so)
         all_data = {"modules": {}}
 
+        # Group modules by position and sort positions in asc order
         config_modules = current_app.config.get("MODULES", [])
 
-        for module_config in config_modules:
-            module_id = module_config.get("id")
-            module_type = module_config.get("type")
-            # TODO Error handling for wrong/missing keys
+        pos_modules = defaultdict(list)
+        for module in config_modules:
+            pos_modules[module["position"]].append(module)
 
-            data = None
-            error = None
-            try:
-                res = requests.get(
-                    url_for(f"api-{module_type}", _external=True),
-                    params={"module_id": module_id},
-                )
-                # TODO Error handling?
-                # Add the error message as module data, so it could be displayed with
-                # a general module-error template that can be included in the module.html
-                # in case this error field is set.
-                data = res.json()
-                res.raise_for_status()
-            except (werkzeug.routing.BuildError, requests.exceptions.HTTPError) as e:
-                msg = str(e)
-                # If we got a better message from the e.g. JSON API, we use it instead
-                if data is not None and "error" in data:
-                    msg = data["msg"]
+        sort_pos_modules = OrderedDict(sorted(pos_modules.items()))
 
-                error = {"code": res.status_code, "msg": msg}
+        for position, module_configs in sort_pos_modules.items():
+            # TODO Check if the actual positions contains more than a single element
+            # and if so, use a carousel/slide with each module
+            for module_config in module_configs:
+                module_id = module_config.get("id")
+                module_type = module_config.get("type")
+                # TODO Error handling for wrong/missing keys
 
-            all_data["modules"][module_id] = {
-                "type": module_type,
-                "config": module_config["config"],
-                "data": data,
-                "error": error,
-            }
+                data = None
+                error = None
+                try:
+                    res = requests.get(
+                        url_for(f"api-{module_type}", _external=True),
+                        params={"module_id": module_id},
+                    )
+                    data = res.json()
+                    res.raise_for_status()
+                except (werkzeug.routing.BuildError, requests.exceptions.HTTPError) as e:
+                    msg = str(e)
+                    # If we got a better message from the e.g. JSON API, we use it instead
+                    if data is not None and "error" in data:
+                        msg = data["msg"]
+
+                    error = {"code": res.status_code, "msg": msg}
+
+                all_data["modules"][module_id] = {
+                    "type": module_type,
+                    "config": module_config["config"],
+                    "data": data,
+                    "error": error,
+                }
 
         context = self.get_context(**all_data)
         return render_template(self.template_name, **context)

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -21,6 +21,7 @@ MODULES = [
         "crawler": {
             "interval": "30s",
         },
+        "position": 0,
     },
     {
         "id": "calendar-personal",
@@ -32,6 +33,7 @@ MODULES = [
         "crawler": {
             "interval": "1m",
         },
+        "position": 1,
     },
     {
         "id": "stocks-series",
@@ -43,6 +45,7 @@ MODULES = [
                 ("GOOGL", "GOOGLE"),
             ],
         },
+        "position": 2,
     },
     {
         "id": "stocks-table",
@@ -55,5 +58,6 @@ MODULES = [
                 ("aapl", "APPLE"),
             ],
         },
+        "position": 3,
     },
 ]

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -4,40 +4,56 @@ SECRET_KEY = '_5#y2L"F4Q8z\n\xec]/'
 
 DATABASE_FILE = "database.sqlite"
 
-MODULES = {
-    "weather-hometown": {
+MODULES = [
+    {
+        "id": "weather-hometown",
         "type": "weather",
-        # Where to retrieve the weather data for
-        "city": "My hometown",
-        # The API key to access openweathermap
-        "api_key": "adskfjkasdjfkjakjfkajksf",
-        # The language in which the weather information is returned by openweathermap
-        "language": "en",
-        # Temperature unit, either "celsius" or "fahrenheit"
-        "temp_unit": "celsius",
-        "interval": "30s",
+        "config": {
+            # Where to retrieve the weather data for
+            "city": "My hometown",
+            # The API key to access openweathermap
+            "api_key": "adskfjkasdjfkjakjfkajksf",
+            # The language in which the weather information is returned by openweathermap
+            "language": "en",
+            # Temperature unit, either "celsius" or "fahrenheit"
+            "temp_unit": "celsius",
+        },
+        "crawler": {
+            "interval": "30s",
+        },
     },
-    "calendar-personal": {
+    {
+        "id": "calendar-personal",
         "type": "calendar",
-        "calendars": ["contacts", "<my-account>@googlemail.com"],
-        "max_items": 5,
-        "interval": "1m",
+        "config": {
+            "calendars": ["contacts", "<my-account>@googlemail.com"],
+            "max_items": 5,
+        },
+        "crawler": {
+            "interval": "1m",
+        },
     },
-    "stocks-series": {
+    {
+        "id": "stocks-series",
         "type": "stocks",
-        "mode": "series",
-        "api_key": "askjfasg89safa",
-        "symbols": [
-            ("GOOGL", "GOOGLE"),
-        ]
+        "config": {
+            "mode": "series",
+            "api_key": "askjfasg89safa",
+            "symbols": [
+                ("GOOGL", "GOOGLE"),
+            ],
+        },
     },
-    "stocks-table": {
+    {
+        "id": "stocks-table",
         "type": "stocks",
-        "mode": "table",
-        "api_key": "askjfasg89safa",
-        "symbols": [
-            ("GOOGL", ""),
-            ("aapl", "APPLE"),
-        ]
+        "config": {
+            "mode": "table",
+            "api_key": "askjfasg89safa",
+            "symbols": [
+                ("GOOGL", ""),
+                ("aapl", "APPLE"),
+            ],
+        },
     },
-}
+]

--- a/settings.example.cfg
+++ b/settings.example.cfg
@@ -21,7 +21,10 @@ MODULES = [
         "crawler": {
             "interval": "30s",
         },
-        "position": 0,
+        "display": {
+            "position": 0,
+            "time": 3000,
+        },
     },
     {
         "id": "calendar-personal",
@@ -33,7 +36,9 @@ MODULES = [
         "crawler": {
             "interval": "1m",
         },
-        "position": 1,
+        "display": {
+            "position": 1,
+        },
     },
     {
         "id": "stocks-series",
@@ -45,7 +50,9 @@ MODULES = [
                 ("GOOGL", "GOOGLE"),
             ],
         },
-        "position": 2,
+        "display": {
+            "position": 2,
+        },
     },
     {
         "id": "stocks-table",
@@ -58,6 +65,8 @@ MODULES = [
                 ("aapl", "APPLE"),
             ],
         },
-        "position": 3,
+        "display": {
+            "position": 3,
+        },
     },
 ]


### PR DESCRIPTION
Changes:

c382059 (Felix Schmidt, 58 seconds ago)
   Make display time of carousel items configurable

979f580 (Felix Schmidt, 30 hours ago)
   Align height of tiles

   This should ensure that the cards always have the same height as the row,
   thus all tiles should have the same height.

d0f304b (Felix Schmidt, 31 hours ago)
   Show multiple modules in a single position as bootstrap carousel

3539ac1 (Felix Schmidt, 2 days ago)
   Group and sort modules by position in index view

   ... to allow combination of multiple modules in a single tile

15d1db5 (Felix Schmidt, 2 days ago)
   Improve structure of configuration file

   This change changes the module config to a list rather than dicts as they
   are simpler to sort. Additionally, it introduces sections in the that
   should help to keep a better overview and allow easier introduction of new
   sections/configuration options.