### PR TITLE
Implement clock module (analog and digital) with JavaScript and CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ dist/
 htmlcov/
 coverage.xml
 
+# Web
+.webassets-cache/
+
 # Development and OS
 .idea
 .DS_Store

--- a/flirror/__init__.py
+++ b/flirror/__init__.py
@@ -1,4 +1,5 @@
 from flask import Flask
+from flask_assets import Bundle, Environment
 
 from .api import CalendarApi, NewsfeedApi, StocksApi, WeatherApi
 from .database import create_database_and_entities
@@ -40,6 +41,11 @@ def create_app():
     app.add_template_filter(prettydate)
     app.add_template_filter(format_time)
     app.add_template_filter(list_filter)
+
+    # Initialize webassets to work with SCSS files
+    assets = Environment(app)
+    scss = Bundle("scss/all.scss", filters="pyscss", output="all.css")
+    assets.register("scss_all", scss)
 
     # Connect to the sqlite database
     # TODO (felix): Maybe we could drop the 'create_db' here?

--- a/flirror/static/all.css
+++ b/flirror/static/all.css
@@ -1,0 +1,239 @@
+.clock-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-family: sans-serif;
+  color: white; }
+
+  .clock {
+    height: 200px;
+    width: 200px;
+    border-radius: 100px;
+    display: flex;
+    justify-content: center;
+    position: relative; }
+    .clock__second, .clock__minute, .clock__hour, .clock__indicator {
+      position: absolute;
+      left: calc(50% - 1px);
+      width: 2px;
+      background: #f4eed7;
+      transform-origin: bottom center;
+      z-index: 2;
+      border-radius: 1px; }
+      .clock__second {
+        height: 90px;
+        margin-top: 10px;
+        background: #4b9aaa;
+        animation: time 60s infinite steps(60);
+        z-index: 3; }
+        .clock__minute {
+          height: 80px;
+          margin-top: 20px;
+          opacity: 0.75;
+          animation: time 3600s linear infinite; }
+          .clock__hour {
+            height: 60px;
+            margin-top: 40px;
+            animation: time 43200s linear infinite; }
+            .clock__indicator {
+              height: 98px;
+              border-top: 2px solid #4b9aaa;
+              background: none; }
+              .clock__indicator:nth-of-type(5n) {
+                opacity: 1;
+                height: 93px;
+                border-top: 7px solid #f4eed7; }
+                .clock__axis {
+                  background: #4b9aaa;
+                  width: 5px;
+                  height: 5px;
+                  border-radius: 3px;
+                  position: absolute;
+                  z-index: 4;
+                  top: 97px; }
+
+section:nth-of-type(1) {
+  transform: rotateZ(calc(6deg * 1)); }
+
+  section:nth-of-type(2) {
+    transform: rotateZ(calc(6deg * 2)); }
+
+    section:nth-of-type(3) {
+      transform: rotateZ(calc(6deg * 3)); }
+
+      section:nth-of-type(4) {
+        transform: rotateZ(calc(6deg * 4)); }
+
+        section:nth-of-type(5) {
+          transform: rotateZ(calc(6deg * 5)); }
+
+          section:nth-of-type(6) {
+            transform: rotateZ(calc(6deg * 6)); }
+
+            section:nth-of-type(7) {
+              transform: rotateZ(calc(6deg * 7)); }
+
+              section:nth-of-type(8) {
+                transform: rotateZ(calc(6deg * 8)); }
+
+                section:nth-of-type(9) {
+                  transform: rotateZ(calc(6deg * 9)); }
+
+                  section:nth-of-type(10) {
+                    transform: rotateZ(calc(6deg * 10)); }
+
+                    section:nth-of-type(11) {
+                      transform: rotateZ(calc(6deg * 11)); }
+
+                      section:nth-of-type(12) {
+                        transform: rotateZ(calc(6deg * 12)); }
+
+                        section:nth-of-type(13) {
+                          transform: rotateZ(calc(6deg * 13)); }
+
+                          section:nth-of-type(14) {
+                            transform: rotateZ(calc(6deg * 14)); }
+
+                            section:nth-of-type(15) {
+                              transform: rotateZ(calc(6deg * 15)); }
+
+                              section:nth-of-type(16) {
+                                transform: rotateZ(calc(6deg * 16)); }
+
+                                section:nth-of-type(17) {
+                                  transform: rotateZ(calc(6deg * 17)); }
+
+                                  section:nth-of-type(18) {
+                                    transform: rotateZ(calc(6deg * 18)); }
+
+                                    section:nth-of-type(19) {
+                                      transform: rotateZ(calc(6deg * 19)); }
+
+                                      section:nth-of-type(20) {
+                                        transform: rotateZ(calc(6deg * 20)); }
+
+                                        section:nth-of-type(21) {
+                                          transform: rotateZ(calc(6deg * 21)); }
+
+                                          section:nth-of-type(22) {
+                                            transform: rotateZ(calc(6deg * 22)); }
+
+                                            section:nth-of-type(23) {
+                                              transform: rotateZ(calc(6deg * 23)); }
+
+                                              section:nth-of-type(24) {
+                                                transform: rotateZ(calc(6deg * 24)); }
+
+                                                section:nth-of-type(25) {
+                                                  transform: rotateZ(calc(6deg * 25)); }
+
+                                                  section:nth-of-type(26) {
+                                                    transform: rotateZ(calc(6deg * 26)); }
+
+                                                    section:nth-of-type(27) {
+                                                      transform: rotateZ(calc(6deg * 27)); }
+
+                                                      section:nth-of-type(28) {
+                                                        transform: rotateZ(calc(6deg * 28)); }
+
+                                                        section:nth-of-type(29) {
+                                                          transform: rotateZ(calc(6deg * 29)); }
+
+                                                          section:nth-of-type(30) {
+                                                            transform: rotateZ(calc(6deg * 30)); }
+
+                                                            section:nth-of-type(31) {
+                                                              transform: rotateZ(calc(6deg * 31)); }
+
+                                                              section:nth-of-type(32) {
+                                                                transform: rotateZ(calc(6deg * 32)); }
+
+                                                                section:nth-of-type(33) {
+                                                                  transform: rotateZ(calc(6deg * 33)); }
+
+                                                                  section:nth-of-type(34) {
+                                                                    transform: rotateZ(calc(6deg * 34)); }
+
+                                                                    section:nth-of-type(35) {
+                                                                      transform: rotateZ(calc(6deg * 35)); }
+
+                                                                      section:nth-of-type(36) {
+                                                                        transform: rotateZ(calc(6deg * 36)); }
+
+                                                                        section:nth-of-type(37) {
+                                                                          transform: rotateZ(calc(6deg * 37)); }
+
+                                                                          section:nth-of-type(38) {
+                                                                            transform: rotateZ(calc(6deg * 38)); }
+
+                                                                            section:nth-of-type(39) {
+                                                                              transform: rotateZ(calc(6deg * 39)); }
+
+                                                                              section:nth-of-type(40) {
+                                                                                transform: rotateZ(calc(6deg * 40)); }
+
+                                                                                section:nth-of-type(41) {
+                                                                                  transform: rotateZ(calc(6deg * 41)); }
+
+                                                                                  section:nth-of-type(42) {
+                                                                                    transform: rotateZ(calc(6deg * 42)); }
+
+                                                                                    section:nth-of-type(43) {
+                                                                                      transform: rotateZ(calc(6deg * 43)); }
+
+                                                                                      section:nth-of-type(44) {
+                                                                                        transform: rotateZ(calc(6deg * 44)); }
+
+                                                                                        section:nth-of-type(45) {
+                                                                                          transform: rotateZ(calc(6deg * 45)); }
+
+                                                                                          section:nth-of-type(46) {
+                                                                                            transform: rotateZ(calc(6deg * 46)); }
+
+                                                                                            section:nth-of-type(47) {
+                                                                                              transform: rotateZ(calc(6deg * 47)); }
+
+                                                                                              section:nth-of-type(48) {
+                                                                                                transform: rotateZ(calc(6deg * 48)); }
+
+                                                                                                section:nth-of-type(49) {
+                                                                                                  transform: rotateZ(calc(6deg * 49)); }
+
+                                                                                                  section:nth-of-type(50) {
+                                                                                                    transform: rotateZ(calc(6deg * 50)); }
+
+                                                                                                    section:nth-of-type(51) {
+                                                                                                      transform: rotateZ(calc(6deg * 51)); }
+
+                                                                                                      section:nth-of-type(52) {
+                                                                                                        transform: rotateZ(calc(6deg * 52)); }
+
+                                                                                                        section:nth-of-type(53) {
+                                                                                                          transform: rotateZ(calc(6deg * 53)); }
+
+                                                                                                          section:nth-of-type(54) {
+                                                                                                            transform: rotateZ(calc(6deg * 54)); }
+
+                                                                                                            section:nth-of-type(55) {
+                                                                                                              transform: rotateZ(calc(6deg * 55)); }
+
+                                                                                                              section:nth-of-type(56) {
+                                                                                                                transform: rotateZ(calc(6deg * 56)); }
+
+                                                                                                                section:nth-of-type(57) {
+                                                                                                                  transform: rotateZ(calc(6deg * 57)); }
+
+                                                                                                                  section:nth-of-type(58) {
+                                                                                                                    transform: rotateZ(calc(6deg * 58)); }
+
+                                                                                                                    section:nth-of-type(59) {
+                                                                                                                      transform: rotateZ(calc(6deg * 59)); }
+
+                                                                                                                      section:nth-of-type(60) {
+                                                                                                                        transform: rotateZ(calc(6deg * 60)); }
+
+                                                                                                                        @keyframes time {
+                                                                                                                          to {
+                                                                                                                            transform: rotateZ(360deg);   }
+}

--- a/flirror/static/all.css
+++ b/flirror/static/all.css
@@ -20,7 +20,8 @@
       background: #f4eed7;
       transform-origin: bottom center;
       z-index: 2;
-      border-radius: 1px; }
+      border-radius: 1px;
+      box-sizing: unset; }
       .clock__second {
         height: 90px;
         margin-top: 10px;

--- a/flirror/static/scss/all.scss
+++ b/flirror/static/scss/all.scss
@@ -1,0 +1,94 @@
+/* The credits for this awesome CSS clock belong to Kyle Wettong (https://codepen.io/kylewetton)
+whose pen https://codepen.io/kylewetton/pen/QJbOjw I found while searching for hints on how to
+visualize a clock with CSS/HTML/JS */
+
+// Clock module
+$black: #1b1e23;
+$size: 200px;
+$white: #f4eed7;
+$feature : #4b9aaa;
+
+.clock-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-family: sans-serif;
+  color: white;
+}
+
+.clock {
+  height: $size;
+  width: $size;
+  border-radius: #{$size / 2};
+  display: flex;
+  justify-content: center;
+  position: relative;
+
+  &__second,
+  &__minute,
+  &__hour, &__indicator {
+    position: absolute;
+    left: calc(50% - 1px);
+    width: 2px;
+    background: $white;
+    transform-origin: bottom center;
+    z-index: 2;
+    border-radius: 1px;
+  }
+
+  &__second {
+    height: #{($size / 2) - 10};
+    margin-top: 10px;
+    background: $feature;
+    animation: time 60s infinite steps(60);
+    z-index: 3;
+  }
+
+  &__minute {
+    height: #{($size / 2) - 20};
+    margin-top: 20px;
+    opacity: 0.75;
+    animation: time 3600s linear infinite;
+  }
+
+  &__hour {
+    height: #{($size / 2) - 40};
+    margin-top: 40px;
+    animation: time 43200s linear infinite;
+  }
+
+  &__indicator {
+    height: #{($size / 2) - 2};
+    border-top: 2px solid $feature;
+    background: none;
+  }
+
+  &__indicator:nth-of-type(5n) {
+    opacity: 1;
+    height: #{($size / 2) - 7};
+    border-top: 7px solid $white;
+  }
+
+  &__axis {
+    background: $feature;
+    width: 5px;
+    height: 5px;
+    border-radius: 3px;
+    position: absolute;
+    z-index: 4;
+    top: #{$size / 2 - 3};
+  }
+}
+
+@for $i from 1 through 60 {
+  section:nth-of-type(#{$i}) {
+    transform: rotateZ(calc(6deg * #{$i}));
+  }
+}
+
+@keyframes time {
+  to {
+    transform: rotateZ(360deg);
+  }
+}

--- a/flirror/static/scss/all.scss
+++ b/flirror/static/scss/all.scss
@@ -35,6 +35,9 @@ $feature : #4b9aaa;
     transform-origin: bottom center;
     z-index: 2;
     border-radius: 1px;
+    /* overwrite bootstrap's border box property. Otherwise the clock is not
+    100% round and the indicators are not properly positioned */
+    box-sizing: unset;
   }
 
   &__second {

--- a/flirror/templates/layout.html
+++ b/flirror/templates/layout.html
@@ -8,6 +8,9 @@
         <!-- custom css -->
         <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
         <link rel="stylesheet" href="{{ url_for('static', filename='css/weather-icons-2.0.10.min.css') }}">
+        {% assets "scss_all" %}
+        <link rel=stylesheet type=text/css href="{{ ASSET_URL }}">
+        {% endassets %}
         <title>Flirror</title>
     </head>
     <body>

--- a/flirror/templates/layout.html
+++ b/flirror/templates/layout.html
@@ -11,14 +11,14 @@
         {% assets "scss_all" %}
         <link rel=stylesheet type=text/css href="{{ ASSET_URL }}">
         {% endassets %}
+        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <title>Flirror</title>
     </head>
     <body>
         <div class="container">
             {% block body %}{% endblock %}
         </div>
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
     </body>
 </html>

--- a/flirror/templates/modules/clock.html
+++ b/flirror/templates/modules/clock.html
@@ -1,4 +1,6 @@
 <div class="card-body">
+    {% if module.config.mode == "analog" %}
+    {# Analog clock UI #}
     <div class="clock-container">
         <h4 class="clock-date pb-2"></h4>
         <div class="clock">
@@ -11,11 +13,24 @@
             {% endfor %}
         </div>
     </div>
+    {% else %}
+    {# Digital clock UI #}
+    <div class="text-center">
+        <h4 class="clock-date medium-emphasis pb-2"></h4>
+        <h1 class="font-weight-light">
+            <span class="clock-time"></span>
+            <small class="font-weight-light">
+                <sup class="clock-seconds disabled"></sup>
+            </small>
+        </h1>
+    </div>
+    {% endif %}
 </div>
+{% if module.config.mode == "analog" %}
+{# Analog clock script #}
 <script>
     // Javascript is used to set the clock to the current computer time.
-    var now = new Date();
-    var currentSec = getSecondsToday(now);
+    var currentSec = getSecondsToday();
 
     var seconds = (currentSec / 60) % 1;
     var minutes = (currentSec / 3600) % 1;
@@ -25,13 +40,12 @@
     setTime(3600 * minutes, "minute");
     setTime(43200 * hours, "hour");
 
-    setDate(now);
-
     function setTime(left, hand) {
         $(".clock__" + hand).css("animation-delay", "" + left * -1 + "s");
     }
 
-    function getSecondsToday(now) {
+    function getSecondsToday() {
+        let now = new Date();
 
         let today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
@@ -39,7 +53,43 @@
         return Math.round(diff / 1000);
     }
 
-    function setDate(now) {
+</script>
+{% else %}
+{# Digital clock script #}
+<script>
+    // Add a String and Number functions to prefix a number with a leading zero
+    String.prototype.lpad = function (padString, length) {
+        var str = this;
+        while (str.length < length)
+            str = padString + str;
+        return str;
+    }
+
+    Number.prototype.lpadZero = function () {
+        return String(this).lpad("0", 2);
+    }
+
+    function setTime() {
+        var now = new Date();
+
+        timeString = now.getHours().lpadZero() + ":" + now.getMinutes().lpadZero();
+        $(".clock-time").text(timeString);
+
+        $(".clock-seconds").text(now.getSeconds().lpadZero());
+    }
+
+    // Update the time every second
+    setInterval(setTime, 1000);
+
+</script>
+{% endif %}
+
+<script>
+    setDate();
+
+    function setDate() {
+        let now = new Date();
+
         var weekdays = [
             "Sunday",
             "Monday",
@@ -63,10 +113,11 @@
             "October",
             "November"
         ]
+
         result = weekdays[now.getDay()] + ", " +
-                 month[now.getMonth()] + " " +
-                 now.getDate() + ", " +
-                 now.getFullYear();
+            month[now.getMonth()] + " " +
+            now.getDate() + ", " +
+            now.getFullYear();
         $(".clock-date").text(result);
     }
 </script>

--- a/flirror/templates/modules/clock.html
+++ b/flirror/templates/modules/clock.html
@@ -57,25 +57,10 @@
 {% else %}
 {# Digital clock script #}
 <script>
-    // Add a String and Number functions to prefix a number with a leading zero
-    String.prototype.lpad = function (padString, length) {
-        var str = this;
-        while (str.length < length)
-            str = padString + str;
-        return str;
-    }
-
-    Number.prototype.lpadZero = function () {
-        return String(this).lpad("0", 2);
-    }
-
     function setTime() {
-        var now = new Date();
-
-        timeString = now.getHours().lpadZero() + ":" + now.getMinutes().lpadZero();
-        $(".clock-time").text(timeString);
-
-        $(".clock-seconds").text(now.getSeconds().lpadZero());
+        var now = moment();
+        $(".clock-time").text(now.format("HH:mm"));
+        $(".clock-seconds").text(now.format("ss"));
     }
 
     // Update the time every second
@@ -84,40 +69,13 @@
 </script>
 {% endif %}
 
+{# Used by both, analog and digital clock #}
 <script>
-    setDate();
-
     function setDate() {
-        let now = new Date();
-
-        var weekdays = [
-            "Sunday",
-            "Monday",
-            "Tuesday",
-            "Wednesday",
-            "Thursday",
-            "Friday",
-            "Saturday"
-        ]
-
-        var month = [
-            "January",
-            "February",
-            "March",
-            "April",
-            "May",
-            "June",
-            "July",
-            "August",
-            "September",
-            "October",
-            "November"
-        ]
-
-        result = weekdays[now.getDay()] + ", " +
-            month[now.getMonth()] + " " +
-            now.getDate() + ", " +
-            now.getFullYear();
-        $(".clock-date").text(result);
+        var now = moment();
+        $(".clock-date").text(now.format("dddd, MMMM DD, YYYYY"));
     }
+
+    // Update the date every second
+    setInterval(setDate, 1000);
 </script>

--- a/flirror/templates/modules/clock.html
+++ b/flirror/templates/modules/clock.html
@@ -1,5 +1,6 @@
 <div class="card-body">
     <div class="clock-container">
+        <h4 class="clock-date pb-2"></h4>
         <div class="clock">
             <div class="clock__second"></div>
             <div class="clock__minute"></div>
@@ -13,7 +14,8 @@
 </div>
 <script>
     // Javascript is used to set the clock to the current computer time.
-    var currentSec = getSecondsToday();
+    var now = new Date();
+    var currentSec = getSecondsToday(now);
 
     var seconds = (currentSec / 60) % 1;
     var minutes = (currentSec / 3600) % 1;
@@ -23,16 +25,48 @@
     setTime(3600 * minutes, "minute");
     setTime(43200 * hours, "hour");
 
+    setDate(now);
+
     function setTime(left, hand) {
         $(".clock__" + hand).css("animation-delay", "" + left * -1 + "s");
     }
 
-    function getSecondsToday() {
-        let now = new Date();
+    function getSecondsToday(now) {
 
         let today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 
         let diff = now - today;
         return Math.round(diff / 1000);
+    }
+
+    function setDate(now) {
+        var weekdays = [
+            "Sunday",
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday"
+        ]
+
+        var month = [
+            "January",
+            "February",
+            "March",
+            "April",
+            "May",
+            "June",
+            "July",
+            "August",
+            "September",
+            "October",
+            "November"
+        ]
+        result = weekdays[now.getDay()] + ", " +
+                 month[now.getMonth()] + " " +
+                 now.getDate() + ", " +
+                 now.getFullYear();
+        $(".clock-date").text(result);
     }
 </script>

--- a/flirror/templates/modules/clock.html
+++ b/flirror/templates/modules/clock.html
@@ -1,0 +1,38 @@
+<div class="card-body">
+    <div class="clock-container">
+        <div class="clock">
+            <div class="clock__second"></div>
+            <div class="clock__minute"></div>
+            <div class="clock__hour"></div>
+            <div class="clock__axis"></div>
+            {% for i in range(60) %}
+            <section class="clock__indicator"></section>
+            {% endfor %}
+        </div>
+    </div>
+</div>
+<script>
+    // Javascript is used to set the clock to the current computer time.
+    var currentSec = getSecondsToday();
+
+    var seconds = (currentSec / 60) % 1;
+    var minutes = (currentSec / 3600) % 1;
+    var hours = (currentSec / 43200) % 1;
+
+    setTime(60 * seconds, "second");
+    setTime(3600 * minutes, "minute");
+    setTime(43200 * hours, "hour");
+
+    function setTime(left, hand) {
+        $(".clock__" + hand).css("animation-delay", "" + left * -1 + "s");
+    }
+
+    function getSecondsToday() {
+        let now = new Date();
+
+        let today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+        let diff = now - today;
+        return Math.round(diff / 1000);
+    }
+</script>

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -63,6 +63,7 @@ class IndexView(FlirrorMethodView):
                 module_type = module_config.get("type")
                 # TODO Error handling for wrong/missing keys
 
+                res = None
                 data = None
                 error = None
                 try:
@@ -81,7 +82,10 @@ class IndexView(FlirrorMethodView):
                     if data is not None and "error" in data:
                         msg = data["msg"]
 
-                    error = {"code": res.status_code, "msg": msg}
+                    code = 500  # TODO Dump default
+                    if res is not None:
+                        code = res.status_code
+                    error = {"code": code, "msg": msg}
 
                 ctx_data["modules"][position].append(
                     {

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,13 @@ requires = [
     "click",
     "feedparser",
     "flask",
+    "Flask-Assets",
     "google-api-python-client",
     "google-auth-httplib2",
     "google-auth-oauthlib",
     "pony",
     "pyowm",
+    "pyScss",
     "schedule",
 ]
 


### PR DESCRIPTION
c8e2c5a (Felix Schmidt, 7 minutes ago)
   Use moment.js to format date/time in clock module

d7df157 (Felix Schmidt, 7 days ago)
   Add webassets-cache directory to gitignore file

40d760f (Felix Schmidt, 7 days ago)
   Make analog clock really round

   Due to bootstrap's border-box property, the indicators of the clock weren't
   positioned equally and the clock itself wasn't 100 percent round.

c4a46b0 (Felix Schmidt, 8 days ago)
   Implement digital clock

85d947f (Felix Schmidt, 8 days ago)
   Show date above clock

eac395b (Felix Schmidt, 11 days ago)
   Add clock module (pure CSS with a little JavaScript)

   I found this at https://codepen.io/kylewetton/pen/QJbOjw and adapted a few
   lines to fit the page layout.

8e992ef (Felix Schmidt, 11 days ago)
   Load javascript files at the top of the page

   Otherwise, we won't be able to use jQuery/$ in custom js parts

d479752 (Felix Schmidt, 11 days ago)
   Use flask-assets to compile SCSS to CSS

   This allows us to work with SCSS file from now on :)

d80324f (Felix Schmidt, 11 days ago)
   Fix: Local variable res is referenced before assignment