### PR TITLE
Implement ajax reloading for all modules

### DIFF
--- a/flirror/__init__.py
+++ b/flirror/__init__.py
@@ -4,7 +4,7 @@ from flask_assets import Bundle, Environment
 from .api import CalendarApi, NewsfeedApi, StocksApi, WeatherApi
 from .database import create_database_and_entities
 from .helpers import make_error_handler
-from .utils import format_time, list_filter, prettydate, weather_icon
+from .utils import clean_string, format_time, list_filter, prettydate, weather_icon
 from .views import CalendarView, IndexView, MapView, WeatherView
 
 FLIRROR_SETTINGS_ENV = "FLIRROR_SETTINGS"
@@ -41,6 +41,7 @@ def create_app():
     app.add_template_filter(prettydate)
     app.add_template_filter(format_time)
     app.add_template_filter(list_filter)
+    app.add_template_filter(clean_string)
 
     # Initialize webassets to work with SCSS files
     assets = Environment(app)

--- a/flirror/templates/ajax.html
+++ b/flirror/templates/ajax.html
@@ -1,0 +1,24 @@
+<script>
+    doAjax();
+
+    function doAjax() {
+        //$("#{{ module.id }}-spinner").addClass("fa-spin");
+        $.ajax({
+            type: 'GET',
+            url: '{{ url_for("api-weather", _external=True) }}',
+            data: {{ {"module_id": module.id} | safe }},
+            success: function (response) {
+                console.log(response.city);
+                $("#{{ module.id }}").html(response._template);
+                // Not necessary, as the card's content will be replaces anyways
+                //$("#{{ module.id }}-spinner").removeClass("fa-spin");
+                // Wait 5 seconds and call doAjax() again
+                setTimeout(doAjax, {{ module.display.refresh | default(5000) }});
+            },
+            error: function (response) {
+                console.log(response);
+                //$("#{{ module.id }}-spinner").removeClass("fa-spin");
+            }
+        });
+    }
+</script>

--- a/flirror/templates/ajax.html
+++ b/flirror/templates/ajax.html
@@ -1,23 +1,35 @@
 <script>
-    doAjax();
+    // Use a unique function name per module, otherwise different doAjax()
+    // might interfere with each other.
+    {% set func_suffix = module.id | clean_string %}
 
-    function doAjax() {
-        //$("#{{ module.id }}-spinner").addClass("fa-spin");
+    doAjax_{{ func_suffix }}();
+
+    function doAjax_{{ func_suffix }}() {
+        // FIXME (felix): This should cause a spin animation during the ajax reload,
+        // but doesn't work.
+        $("#{{ module.id }}-spinner").addClass("fa-spin");
         $.ajax({
+            // TODO Set timeout?
             type: 'GET',
-            url: '{{ url_for("api-weather", _external=True) }}',
+            url: '{{ url_for("api-" + module.type, _external=True) }}',
             data: {{ {"module_id": module.id, "output": "template"} | safe }},
             success: function (response) {
-                console.log(response.city);
+                // TODO Remove debug output
+                console.log("{{ module.id }}")
                 $("#{{ module.id }}").html(response._template);
-                // Not necessary, as the card's content will be replaces anyways
+                // Not necessary, as the card's content will be replaced anyways
                 //$("#{{ module.id }}-spinner").removeClass("fa-spin");
-                // Wait 5 seconds and call doAjax() again
-                setTimeout(doAjax, {{ module.display.refresh | default(5000) }});
+                // Wait 30 seconds and call doAjax() again
+                setTimeout(
+                    doAjax_{{ func_suffix }},
+                    {{ module.display.refresh | default(30000) }}
+                );
             },
             error: function (response) {
                 console.log(response);
-                //$("#{{ module.id }}-spinner").removeClass("fa-spin");
+                // FIXME (felix): Doesn' work either, see above
+                $("#{{ module.id }}-spinner").removeClass("fa-spin");
             }
         });
     }

--- a/flirror/templates/ajax.html
+++ b/flirror/templates/ajax.html
@@ -6,7 +6,7 @@
         $.ajax({
             type: 'GET',
             url: '{{ url_for("api-weather", _external=True) }}',
-            data: {{ {"module_id": module.id} | safe }},
+            data: {{ {"module_id": module.id, "output": "template"} | safe }},
             success: function (response) {
                 console.log(response.city);
                 $("#{{ module.id }}").html(response._template);

--- a/flirror/templates/index.html
+++ b/flirror/templates/index.html
@@ -29,6 +29,9 @@
                 {% for module in modules %}
                 <div class="col-6 align-items-stretch">
                     {% include "modules/" + module.type + ".html" ignore missing %}
+                    {% if module.type == "weather" %}
+                        {% include "ajax.html" %}
+                    {% endif %}
                 </div>
                 {% endfor %}
             {% endif %}

--- a/flirror/templates/index.html
+++ b/flirror/templates/index.html
@@ -19,7 +19,13 @@
                     <div class="carousel-inner">
                         {% for module in modules %}
                         <div class="carousel-item {% if loop.first %}active{% endif %}" data-interval="{{ module.display.get('time', 5000) }}">
+                            <div id="{{ module.id }}" class="card dark">
                             {% include "modules/" + module.type + ".html" ignore missing %}
+                            </div>
+                            {# TODO Find a better condition - pure JS/CSS modules don't need ajax here #}
+                            {% if module.type != "clock" %}
+                                {% include "ajax.html" %}
+                            {% endif %}
                         </div>
                         {% endfor %}
                     </div>
@@ -28,8 +34,11 @@
             {% else %}
                 {% for module in modules %}
                 <div class="col-6 align-items-stretch">
+                    <div id="{{ module.id }}" class="card dark">
                     {% include "modules/" + module.type + ".html" ignore missing %}
-                    {% if module.type == "weather" %}
+                    </div>
+                    {# TODO Find a better condition - pure JS/CSS modules don't need ajax here #}
+                    {% if module.type != "clock" %}
                         {% include "ajax.html" %}
                     {% endif %}
                 </div>

--- a/flirror/templates/layout.html
+++ b/flirror/templates/layout.html
@@ -11,7 +11,7 @@
         {% assets "scss_all" %}
         <link rel=stylesheet type=text/css href="{{ ASSET_URL }}">
         {% endassets %}
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+        <script src="http://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <title>Flirror</title>

--- a/flirror/templates/layout.html
+++ b/flirror/templates/layout.html
@@ -14,6 +14,7 @@
         <script src="http://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js"></script>
         <title>Flirror</title>
     </head>
     <body>

--- a/flirror/templates/module.html
+++ b/flirror/templates/module.html
@@ -1,12 +1,10 @@
-<div class="card dark">
     {% if module.error %}
     <div class="card-body text-center">
         <h1 class="error"><i class="fas fa-sad-tear"></i> Error {{ module.error.code }}</h1>
         <p class="card-text">
-           {{ module.error.msg }}
+            {{ module.error.msg }}
         </p>
     </div>
     {% else %}
     {% block body %}{% endblock %}
     {% endif %}
-</div>

--- a/flirror/templates/modules/calendar.html
+++ b/flirror/templates/modules/calendar.html
@@ -4,7 +4,7 @@
 <div class="card-body">
     <div class="text-right">
         <small>
-            <i class="fas fa-sync-alt"></i> {{ module.data._timestamp | prettydate }}
+            <i id="{{ module.id }}-spinner" class="fas fa-sync-alt"></i> {{ module.data._timestamp | prettydate }}
         </small>
     </div>
     {% for item in module.data.events %}

--- a/flirror/templates/modules/clock.html
+++ b/flirror/templates/modules/clock.html
@@ -41,7 +41,7 @@
     setTime(43200 * hours, "hour");
 
     function setTime(left, hand) {
-        $(".clock__" + hand).css("animation-delay", "" + left * -1 + "s");
+        $("#{{ module.id }} .clock__" + hand).css("animation-delay", "" + left * -1 + "s");
     }
 
     function getSecondsToday() {

--- a/flirror/templates/modules/clock.html
+++ b/flirror/templates/modules/clock.html
@@ -73,7 +73,7 @@
 <script>
     function setDate() {
         var now = moment();
-        $(".clock-date").text(now.format("dddd, MMMM DD, YYYYY"));
+        $(".clock-date").text(now.format("dddd, MMMM DD, YYYY"));
     }
 
     // Update the date every second

--- a/flirror/templates/modules/newsfeed.html
+++ b/flirror/templates/modules/newsfeed.html
@@ -4,7 +4,7 @@
 <div class="card-body">
     <div class="text-right">
         <small>
-            <i class="fas fa-sync-alt"></i> {{ module.data._timestamp | prettydate }}
+            <i id="{{ module.id }}-spinner" class="fas fa-sync-alt"></i> {{ module.data._timestamp | prettydate }}
         </small>
     </div>
     {% set entry = module.data.news[0] %}

--- a/flirror/templates/modules/stocks.html
+++ b/flirror/templates/modules/stocks.html
@@ -4,7 +4,7 @@
 <div class="card-body">
     <div class="text-right">
         <small>
-            <i class="fas fa-sync-alt"></i> {{ module.data._timestamp | prettydate }}
+            <i id="{{ module.id }}-spinner" class="fas fa-sync-alt"></i> {{ module.data._timestamp | prettydate }}
         </small>
     </div>
     {% if module.config.mode == "series" %}

--- a/flirror/templates/modules/stocks.html
+++ b/flirror/templates/modules/stocks.html
@@ -10,7 +10,6 @@
     {% if module.config.mode == "series" %}
     <canvas id="chart-{{ module.id }}" width="400" height="400"></canvas>
     {# NOTE: Moment.js must be included before Chart.js to make the time axis work #}
-    <script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js"
         integrity="sha256-Uv9BNBucvCPipKQ2NS9wYpJmi8DTOEfTA/nH2aoJALw=" crossorigin="anonymous">
     </script>

--- a/flirror/templates/modules/weather.html
+++ b/flirror/templates/modules/weather.html
@@ -1,10 +1,10 @@
 {% extends "module.html" %}
 
 {% block body %}
-<div class="card-body text-center">
+<div id="{{ module.id }}" class="card-body text-center">
     <div class="text-right">
         <small>
-            <i class="fas fa-sync-alt"></i> {{ module.data._timestamp | prettydate }}
+            <i id="{{ module.id }}-spinner" class="fas fa-sync-alt"></i> {{ module.data._timestamp | prettydate }}
         </small>
     </div>
     <h3><strong>{{ module.data.city }}</strong></h3>

--- a/flirror/templates/modules/weather.html
+++ b/flirror/templates/modules/weather.html
@@ -1,7 +1,7 @@
 {% extends "module.html" %}
 
 {% block body %}
-<div id="{{ module.id }}" class="card-body text-center">
+<div class="card-body text-center">
     <div class="text-right">
         <small>
             <i id="{{ module.id }}-spinner" class="fas fa-sync-alt"></i> {{ module.data._timestamp | prettydate }}

--- a/flirror/templates/modules/weather.html
+++ b/flirror/templates/modules/weather.html
@@ -26,8 +26,6 @@
         </div>
     </div>
     <div class="col-2"></div>
-</div>
-<div class="card-footer text-center">
     <div class="row">
         {% for fc in module.data.forecasts %}
         <div class="col-2">

--- a/flirror/utils.py
+++ b/flirror/utils.py
@@ -73,3 +73,17 @@ def format_time(timestamp, format):
 
 def list_filter(list_of_dicts_to_filter, key):
     return [d[key] for d in list_of_dicts_to_filter]
+
+
+def clean_string(string):
+    """
+    Taken from Django:
+    https://github.com/django/django/blob/e3d0b4d5501c6d0bc39f035e4345e5bdfde12e41/django/utils/text.py#L222
+
+    Return the given string converted to a string that can be used for a clean
+    filename. Remove leading and trailing spaces; convert other spaces to
+    underscores; and remove anything that is not an alphanumeric, dash,
+    underscore, or dot.
+    """
+    string = str(string).strip().replace(" ", "_").replace("-", "_")
+    return re.sub(r"(?u)[^-\w.]", "", string)

--- a/flirror/views.py
+++ b/flirror/views.py
@@ -69,7 +69,7 @@ class IndexView(FlirrorMethodView):
                 try:
                     res = requests.get(
                         url_for(f"api-{module_type}", _external=True),
-                        params={"module_id": module_id},
+                        params={"module_id": module_id, "output": "raw"},
                     )
                     data = res.json()
                     res.raise_for_status()


### PR DESCRIPTION
To make the Jinja2 templates reusable also within the Ajax calls, this
introduces a new "output" parameter for the module API that allows
returning the result in raw format or as template. The first one is
still used to initially fill the index view during page load. The
template is used by the ajax calls to simply replace the HTML within
the module divs.

b18c448 (Felix Schmidt, 3 weeks ago)
   Enable ajax reloading for all modules

   Except for the clock, as this is a pure JS/CSS module which doesn't need
   any backend data.

501ef95 (Felix Schmidt, 3 weeks ago)
   Refactor current API endpoints to support raw and template output

41915c5 (Felix Schmidt, 3 weeks ago)
   Use output parameter for API to differentiate between raw and template

87b78c7 (Felix Schmidt, 4 weeks ago)
   Fix wrong year formatting in clock tile

19e537e (Felix Schmidt, 4 weeks ago)
   POC for ajax reloading with the weather module

c7629e3 (Felix Schmidt, 4 weeks ago)
   Include moment.js globally (not just for the stocks module)

06e143d (Felix Schmidt, 4 weeks ago)
   Wrap weather tile in single card-body element (like all other modules)

dbdca55 (Felix Schmidt, 4 weeks ago)
   Update jQuery to 3.4.1 and use normal version

   The slim version we used so far does not support ajax calls.